### PR TITLE
fix(deploy): добавить basePath для GitHub Pages

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -34,6 +34,8 @@ jobs:
         uses: actions/configure-pages@v5
       - name: Build with Next.js
         run: pnpm build
+        env:
+          GITHUB_PAGES: "true"
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,7 @@
 import createMDX from "@next/mdx";
 
+const isGithubPages = process.env.GITHUB_PAGES === "true";
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   pageExtensions: ["js", "jsx", "md", "mdx", "ts", "tsx"],
@@ -7,6 +9,10 @@ const nextConfig = {
     unoptimized: true,
   },
   output: "export",
+  ...(isGithubPages && {
+    basePath: "/blog",
+    assetPrefix: "/blog",
+  }),
 };
 
 const withMDX = createMDX({});


### PR DESCRIPTION
GitHub Pages раздаёт сайт по /blog/, без basePath все ресурсы возвращали 404. Переменная GITHUB_PAGES=true активирует basePath только при сборке для Pages, не затрагивая VPS-деплой.