### PR TITLE
fix(blog): картинки блога и OG на GitHub Pages

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -3,11 +3,9 @@ import { notFound } from "next/navigation";
 
 import { formatDate, getBlogPosts } from "@/app/blog/utils";
 import { CustomMDX } from "@/components/mdx/mdx";
-import { MAIN_CONTENT_ID } from "@/constants/common";
+import { MAIN_CONTENT_ID, SITE_ORIGIN } from "@/constants/common";
 
 import type { Metadata } from "next";
-
-const BASE_URL = "https://per0w.space";
 
 export async function generateStaticParams() {
   const posts = getBlogPosts();
@@ -33,7 +31,9 @@ export async function generateMetadata(props: Params) {
   }
 
   const { title, publishedAt: publishedTime, description, image } = post.metadata;
-  const ogImage = image ? image : `${BASE_URL}/og?title=${encodeURIComponent(title)}`;
+  const ogImage = image
+    ? `${SITE_ORIGIN}${image}`
+    : `${SITE_ORIGIN}/og?title=${encodeURIComponent(title)}`;
 
   return {
     title: `${title} | per0w.space`,
@@ -43,7 +43,7 @@ export async function generateMetadata(props: Params) {
       description,
       type: "article",
       publishedTime,
-      url: `${BASE_URL}/blog/${post.slug}`,
+      url: `${SITE_ORIGIN}/blog/${post.slug}`,
       images: [{ url: ogImage }],
     },
     twitter: {
@@ -80,9 +80,9 @@ export default async function BlogPost(props: Params) {
             dateModified: post.metadata.publishedAt,
             description: post.metadata.description,
             image: post.metadata.image
-              ? `${BASE_URL}${post.metadata.image}`
-              : `${BASE_URL}/og?title=${encodeURIComponent(post.metadata.title)}`,
-            url: `${BASE_URL}/blog/${post.slug}`,
+              ? `${SITE_ORIGIN}${post.metadata.image}`
+              : `${SITE_ORIGIN}/og?title=${encodeURIComponent(post.metadata.title)}`,
+            url: `${SITE_ORIGIN}/blog/${post.slug}`,
             author: {
               "@type": "Person",
               name: "Владимир Перов",

--- a/src/components/experience/experience-title-easter-egg.tsx
+++ b/src/components/experience/experience-title-easter-egg.tsx
@@ -7,6 +7,7 @@ import Image from "next/image";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import { X } from "lucide-react";
 
+import { withBasePath } from "@/constants/base-path";
 import { ORBO_EASTER_EGG_HINT_EVENT } from "@/constants/common";
 
 const REQUIRED_CLICKS = 10;
@@ -63,8 +64,8 @@ export const ExperienceTitleEasterEgg = ({
     typeof photoIntrinsicHeight === "number" &&
     photoIntrinsicWidth > 0 &&
     photoIntrinsicHeight > 0;
-  const isLandscapePhoto =
-    hasIntrinsicSize && photoIntrinsicWidth >= photoIntrinsicHeight;
+  const isLandscapePhoto = hasIntrinsicSize && photoIntrinsicWidth >= photoIntrinsicHeight;
+  const resolvedPhotoSrc = withBasePath(photoSrc);
 
   useEffect(() => {
     if (!isOpen) {
@@ -152,7 +153,7 @@ export const ExperienceTitleEasterEgg = ({
               exit={reduceMotion ? { opacity: 0 } : { opacity: 0, scale: 0.96, y: 16 }}
               initial={reduceMotion ? { opacity: 0 } : { opacity: 0, scale: 0.92, y: 24 }}
               transition={{ duration: 0.32, ease: "easeOut" }}
-              className={`relative max-h-[min(92vh,56rem)] w-full overflow-y-auto overflow-x-hidden rounded-[2rem] border border-accent/20 bg-surface/95 p-4 shadow-[0_24px_80px_-24px_color-mix(in_srgb,var(--color-accent)_40%,transparent)] sm:p-6 ${
+              className={`relative max-h-[min(92vh,56rem)] w-full overflow-x-hidden overflow-y-auto rounded-[2rem] border border-accent/20 bg-surface/95 p-4 shadow-[0_24px_80px_-24px_color-mix(in_srgb,var(--color-accent)_40%,transparent)] sm:p-6 ${
                 isLandscapePhoto ? "max-w-3xl" : "max-w-xl"
               }`}
               onClick={(event) => event.stopPropagation()}
@@ -170,7 +171,9 @@ export const ExperienceTitleEasterEgg = ({
                   <h4 className="mt-2 text-2xl font-black text-foreground" id={dialogTitleId}>
                     {modalHeading}
                   </h4>
-                  <p className="mt-2 max-w-md text-sm leading-relaxed text-muted">{modalDescription}</p>
+                  <p className="mt-2 max-w-md text-sm leading-relaxed text-muted">
+                    {modalDescription}
+                  </p>
                 </div>
 
                 <button
@@ -200,7 +203,7 @@ export const ExperienceTitleEasterEgg = ({
                       alt={photoAlt}
                       className="h-auto max-h-[min(58vh,560px)] w-auto max-w-full object-contain"
                       height={photoIntrinsicHeight}
-                      src={photoSrc}
+                      src={resolvedPhotoSrc}
                       width={photoIntrinsicWidth}
                       sizes={
                         isLandscapePhoto
@@ -217,7 +220,7 @@ export const ExperienceTitleEasterEgg = ({
                       alt={photoAlt}
                       className="object-contain"
                       sizes="(max-width: 768px) 90vw, 480px"
-                      src={photoSrc}
+                      src={resolvedPhotoSrc}
                     />
                   </div>
                 )}

--- a/src/components/mdx/mdx.tsx
+++ b/src/components/mdx/mdx.tsx
@@ -13,6 +13,7 @@ import remarkGfm from "remark-gfm";
 import { highlight } from "sugar-high";
 
 import { LivePlayground } from "@/components/mdx/live-playground";
+import { withBasePath } from "@/constants/base-path";
 
 type TablProps = {
   data: {
@@ -69,6 +70,21 @@ function RoundedImage(props: RoundedImageProps) {
   return <Image className="rounded-lg" {...props} alt={props.alt} />;
 }
 
+/**
+ * Markdown-изображения: путь из public/ без учёта basePath — дописываем для GitHub Pages.
+ * Не next/image: в MDX у картинок нет единых width/height.
+ */
+function MdxImg(
+  props: DetailedHTMLProps<React.ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement>,
+) {
+  const { src, alt, ...rest } = props;
+  const resolved = typeof src === "string" ? withBasePath(src) : src;
+  return (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img {...rest} alt={alt ?? ""} src={resolved} />
+  );
+}
+
 function Code({
   children,
   ...props
@@ -120,6 +136,7 @@ const components = {
   h5: createHeading(5),
   h6: createHeading(6),
   Image: RoundedImage,
+  img: MdxImg,
   a: CustomLink,
   code: Code,
   LivePlayground,

--- a/src/ui/blog-post-card/blog-post-card.tsx
+++ b/src/ui/blog-post-card/blog-post-card.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image";
 import Link from "next/link";
 
+import { withBasePath } from "@/constants/base-path";
 import { Tags } from "@/ui/tags/tags";
 
 import { BlogPostPreviewArt } from "./blog-post-preview-art";
@@ -54,7 +55,7 @@ export function BlogPostCard({
                 alt=""
                 className="size-full object-cover"
                 height={160}
-                src={coverImage}
+                src={withBasePath(coverImage)}
                 width={160}
               />
             ) : (


### PR DESCRIPTION
## Проблема
При деплое на GitHub Pages с `basePath: /blog` запросы шли на `/images/blog/...` вместо `/blog/images/blog/...`, из‑за чего обложки и иллюстрации в MDX отдавали 404.

## Изменения
- `BlogPostCard`: `withBasePath` для `src` обложки
- `CustomMDX`: кастомный `img` с `withBasePath` для путей из `public/`
- Страница поста: `SITE_ORIGIN` вместо захардкоженного домена для `og:image`, `openGraph.url` и JSON-LD

## Проверка
- `GITHUB_PAGES=true NEXT_PUBLIC_SITE_URL=https://per0w.github.io/blog pnpm build` — в HTML `/blog/images/blog/...` и корректный `og:image`.