### PR TITLE
fix(components): стабилизировать комментарии Орбо при быстром скролле

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -481,17 +481,21 @@ table {
 .hero-cyber-title-wrap {
   position: relative;
   display: inline-block;
+  max-width: 100%;
   line-height: 1.05;
 }
 
-/* Верх рамки не уходит в минус — иначе линия HUD пересекает строку «Привет!» над h1 */
+/*
+ * Рамка по контуру букв: минимальный вылет по горизонтали — иначе «коробка» визуально
+ * шире строки «Привет!» и кажется, что приветствие заезжает под HUD.
+ */
 .hero-cyber-hud {
   pointer-events: none;
   position: absolute;
   z-index: 0;
-  inset: 0 -0.5em -0.35em -0.5em;
+  inset: 0 -0.06em -0.2em -0.06em;
   border: 1px solid color-mix(in srgb, var(--color-accent) 28%, transparent);
-  border-radius: 0.2em;
+  border-radius: 0.12em;
   opacity: 0.65;
   animation: hero-cyber-hud-pulse 5s ease-in-out infinite;
 }
@@ -697,7 +701,7 @@ table {
   .hero-cyber-hud {
     animation: none;
     opacity: 0.5;
-    inset: 0 -0.28em -0.15em -0.28em;
+    inset: 0 -0.06em -0.12em -0.06em;
   }
 
   .hero-cyber-title-main {
@@ -720,10 +724,11 @@ table {
 
   50% {
     opacity: 1;
+    /* Умеренный радиус — меньше «протечки» вниз на заголовок с HUD */
     text-shadow:
       0 0 1px color-mix(in srgb, var(--color-accent-secondary) 45%, transparent),
-      0 0 14px color-mix(in srgb, var(--color-accent-secondary) 50%, transparent),
-      0 0 28px color-mix(in srgb, var(--color-accent) 28%, transparent);
+      0 0 10px color-mix(in srgb, var(--color-accent-secondary) 42%, transparent),
+      0 0 20px color-mix(in srgb, var(--color-accent) 22%, transparent);
   }
 }
 
@@ -742,6 +747,7 @@ table {
 }
 
 .hero-greet-cyber-soft {
+  display: inline-block;
   animation: hero-greet-cyber-glow 5.2s ease-in-out infinite;
 }
 

--- a/src/components/ai-buddy/ai-buddy.tsx
+++ b/src/components/ai-buddy/ai-buddy.tsx
@@ -1,178 +1,44 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 
 import { createPortal } from "react-dom";
 
 import { motion } from "framer-motion";
 import { Sparkles } from "lucide-react";
 
+import { useOrboBootstrap } from "@/components/ai-buddy/hooks/use-orbo-bootstrap";
+import { useOrboCursorHover } from "@/components/ai-buddy/hooks/use-orbo-cursor-hover";
+import { useOrboCvPage } from "@/components/ai-buddy/hooks/use-orbo-cv-page";
+import { useOrboGlobalEvents } from "@/components/ai-buddy/hooks/use-orbo-global-events";
+import { useOrboLean } from "@/components/ai-buddy/hooks/use-orbo-lean";
+import { useOrboMainSections } from "@/components/ai-buddy/hooks/use-orbo-main-sections";
+import { useOrboPeek } from "@/components/ai-buddy/hooks/use-orbo-peek";
+import { useOrboScroll } from "@/components/ai-buddy/hooks/use-orbo-scroll";
 import { OrbAvatar, type OrbMood } from "@/components/ai-buddy/orb-avatar";
 import { CommentTooltip } from "@/components/ai-buddy/orbo-comment-tooltip";
 import {
-  AI_PROMPT_TEMPLATE,
   ANNOYED_COMMENTS,
-  CONTACT_FORM_SPAM_COMMENTS,
-  COPY_TEXT_COMMENTS,
-  CURSOR_COMMENTS,
-  CURSOR_HOVER_DELAY,
   CV_CLICK_COMMENTS,
-  CV_ROLE_CHANGE_COMMENTS,
   CV_ROLE_CLICK_COMMENTS,
-  CV_ROLE_DWELL_COMMENTS,
-  CV_ROLE_FOCUS_SECTIONS,
-  CV_ROLE_HIRE_NUDGES,
-  CV_ROLE_SIGNAL_SECTIONS,
-  detectElementType,
-  EXPERIENCE_TOOLTIP_COMMENTS,
-  FAST_SCROLL_COMMENTS,
-  getContextualComment,
-  getCvActionComment,
-  getCvItemComment,
-  getCvSectionComment,
-  getImpactProjectCardHoverComment,
   getRandomComment,
-  getSelectionComment,
-  IDLE_COMMENTS,
-  MAX_ORBO_COMMENTS,
-  PAGE_BOTTOM_COMMENTS,
   pickRandom,
-  RESIZE_WINDOW_COMMENTS,
-  SCROLL_BACK_COMMENTS,
   SECTION_COMMENTS,
-  SECTION_NAMES,
-  TAB_RETURN_COMMENTS,
-  THEME_DARK_COMMENTS,
-  THEME_LIGHT_COMMENTS,
 } from "@/components/ai-buddy/orbo-data";
 import {
-  CV_READER_ROLES,
-  ORBO_CONTACT_SPAM_EVENT,
-  ORBO_CV_ROLE_CHANGE_EVENT,
-  ORBO_EASTER_EGG_HINT_EVENT,
-  ORBO_HERO_GREETING_REPLY_EVENT,
-  ORBO_MAX_HOVER_EVENT,
-  SECTIONS_IDS,
-  type CvReaderRole,
-} from "@/constants/common";
-import {
-  getOpenRouterApiKey,
-  ORBO_OPENROUTER_COOLDOWN_MS,
-  ORBO_OPENROUTER_MAX_FALLBACK_ATTEMPTS,
-} from "@/constants/contact-form";
+  ORBO_DISMISSED_STORAGE_KEY,
+  ORBO_DISPLAY_DURATION_MS,
+  ORBO_MIN_THINKING_MS,
+  ORBO_TAP_COUNT_RESET_MS,
+} from "@/constants/ai-buddy";
+import { CV_READER_ROLES, type CvReaderRole } from "@/constants/common";
 import { HERO_GREETING_BUBBLE_REPLY_FOCUS_MS } from "@/constants/hero-greeting";
-import { openRouterChatCompletion } from "@/utils/openrouter-client";
-
-/** Сериализация вызовов OpenRouter из Орбо (один за другим, без «return null»). */
-let orboOpenRouterLastAttemptAt = 0;
-let orboOpenRouterMutexTail: Promise<void> = Promise.resolve();
-
-async function withOrboOpenRouterSlot<T>(fn: () => Promise<T>): Promise<T> {
-  const prev = orboOpenRouterMutexTail;
-  let release!: () => void;
-  orboOpenRouterMutexTail = new Promise<void>((resolve) => {
-    release = resolve;
-  });
-  await prev;
-  try {
-    return await fn();
-  } finally {
-    release();
-  }
-}
-
-const STORAGE_KEY = "ai-buddy-dismissed";
-const DISPLAY_DURATION = 6000;
-const ORBO_MIN_THINKING_MS = 850;
-const SECTION_QUEUE_GAP_MS = DISPLAY_DURATION + 2800;
-const AI_TIMEOUT = 3000;
-const IDLE_DELAY = 30_000;
-const TAP_COUNT_RESET_MS = 15_000;
-
-async function getAiComment(sectionId: string): Promise<string | null> {
-  const sectionName = SECTION_NAMES[sectionId] ?? sectionId;
-  const prompt = AI_PROMPT_TEMPLATE(sectionName);
-
-  if (getOpenRouterApiKey()) {
-    const fromOpenRouter = await withOrboOpenRouterSlot(async () => {
-      const now = Date.now();
-      if (now - orboOpenRouterLastAttemptAt < ORBO_OPENROUTER_COOLDOWN_MS) {
-        return null;
-      }
-      orboOpenRouterLastAttemptAt = Date.now();
-
-      const ac = new AbortController();
-      const t = window.setTimeout(() => ac.abort(), 12_000);
-      try {
-        const or = await openRouterChatCompletion({
-          userContent: prompt,
-          maxTokens: 120,
-          temperature: 0.55,
-          xTitle: "per0w.space - Orbo",
-          signal: ac.signal,
-          maxFallbackAttempts: ORBO_OPENROUTER_MAX_FALLBACK_ATTEMPTS,
-        });
-        if (or.ok) {
-          const line = or.text.replace(/\s+/g, " ").trim().slice(0, 280);
-          return line.length > 0 ? line : null;
-        }
-      } catch {
-        /* падаем на встроенную модель Chrome */
-      } finally {
-        window.clearTimeout(t);
-      }
-      return null;
-    });
-    if (fromOpenRouter) return fromOpenRouter;
-  }
-
-  try {
-    if (typeof LanguageModel === "undefined") return null;
-
-    const availability = await LanguageModel.availability();
-    if (availability === "unavailable") return null;
-
-    const createPromise = LanguageModel.create();
-    try {
-      const session = await Promise.race([
-        createPromise,
-        new Promise<never>((_, reject) =>
-          setTimeout(() => reject(new Error("timeout")), AI_TIMEOUT),
-        ),
-      ]);
-      try {
-        const result = await session.prompt(prompt);
-        return result?.trim() || null;
-      } finally {
-        session.destroy();
-      }
-    } catch {
-      /* Таймаут гонки: create() всё равно может завершиться — обязательно destroy. */
-      void createPromise
-        .then((s) => {
-          try {
-            s.destroy();
-          } catch {
-            /* сессия уже закрыта */
-          }
-        })
-        .catch(() => {});
-      return null;
-    }
-  } catch {
-    return null;
-  }
-}
-
-function isCapableDevice(): boolean {
-  if (typeof navigator === "undefined") return false;
-  const cores = navigator.hardwareConcurrency ?? 0;
-  const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-  if (reducedMotion) return false;
-  if (cores < 4) return false;
-  if (window.innerWidth < 768) return false;
-  return true;
-}
+import { getOrboAiComment } from "@/utils/orbo-ai-comment";
+import { logOrboDebug } from "@/utils/orbo-debug";
+import {
+  getSectionVerticalVisibilityRatio,
+  MIN_SECTION_VISIBILITY_RATIO,
+} from "@/utils/orbo-visibility";
 
 function SimpleAvatar({ speaking, compact }: { speaking: boolean; compact?: boolean }) {
   const size = compact ? "size-10" : "size-12";
@@ -196,20 +62,18 @@ const ORBO_FLOAT_CLASS =
   "fixed z-[100] [contain:layout] max-sm:right-0 max-sm:bottom-[max(1rem,env(safe-area-inset-bottom,0px))] max-sm:left-0 max-sm:flex max-sm:justify-center sm:bottom-[max(1.5rem,env(safe-area-inset-bottom,0px))] sm:right-[max(1.5rem,env(safe-area-inset-right,0px))] sm:left-auto";
 
 export function AiBuddy() {
+  const { portalReady, dismissed, setDismissed, enhanced, isMobile, isCvPage } = useOrboBootstrap();
+
   const [comment, setComment] = useState<string | null>(null);
   const [tooltipVisible, setTooltipVisible] = useState(false);
   const [speaking, setSpeaking] = useState(false);
   const [isThinking, setIsThinking] = useState(false);
   const [commentSlideKey, setCommentSlideKey] = useState(0);
-  const [dismissed, setDismissed] = useState(true);
-  const [enhanced, setEnhanced] = useState(false);
-  const [isMobile, setIsMobile] = useState(false);
-  const [isCvPage, setIsCvPage] = useState(false);
-  const [portalReady, setPortalReady] = useState(false);
   const [orbMood, setOrbMood] = useState<OrbMood>("neutral");
   const [orbIdleDrowsy, setOrbIdleDrowsy] = useState(false);
   const [lean, setLean] = useState({ x: 0, y: 0 });
-  const [peekDismissed, setPeekDismissed] = useState(false);
+
+  const peekDismissed = useOrboPeek(dismissed);
 
   const lastSectionRef = useRef<string | null>(null);
   const displayTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -223,93 +87,11 @@ export function AiBuddy() {
   const cvHireNudgeShownRef = useRef(false);
   const cvDwellShownRef = useRef<Set<string>>(new Set());
   const hireNudgeTimerRef = useRef<number | null>(null);
-  /** Пайплайн комментария по секции (OpenRouter / Chrome AI): не перебивать скроллом и ховером. */
   const orboSectionPipelineRef = useRef(false);
-  /** После ответа по секции — короткая пауза, пока догорает инерция скролла. */
   const orboSuppressAmbientUntilRef = useRef(0);
+  const sectionCommentEpochRef = useRef(0);
 
-  useEffect(() => {
-    setPortalReady(true);
-    try {
-      setDismissed(sessionStorage.getItem(STORAGE_KEY) === "true");
-    } catch {
-      setDismissed(false);
-    }
-
-    const syncViewport = () => {
-      setEnhanced(isCapableDevice());
-      setIsMobile(window.innerWidth < 640);
-      const path = window.location.pathname.replace(/\/+$/, "") || "/";
-      const cvPath = `${process.env.NEXT_PUBLIC_BASE_PATH ?? ""}/cv`;
-      setIsCvPage(path === cvPath || path.startsWith(`${cvPath}/`));
-    };
-
-    syncViewport();
-    const mqReduce = window.matchMedia("(prefers-reduced-motion: reduce)");
-    mqReduce.addEventListener("change", syncViewport);
-    window.addEventListener("resize", syncViewport, { passive: true });
-    return () => {
-      mqReduce.removeEventListener("change", syncViewport);
-      window.removeEventListener("resize", syncViewport);
-    };
-  }, []);
-
-  useEffect(() => {
-    if (!isCvPage) {
-      cvRoleRef.current = CV_READER_ROLES.hr;
-      cvSeenSignalsRef.current.clear();
-      cvDwellShownRef.current.clear();
-      cvHireNudgeShownRef.current = false;
-      return;
-    }
-
-    cvSeenSignalsRef.current.clear();
-    cvDwellShownRef.current.clear();
-    cvHireNudgeShownRef.current = false;
-  }, [isCvPage]);
-
-  useEffect(() => {
-    if (!dismissed) return;
-    const id = window.setInterval(() => {
-      setPeekDismissed(true);
-      window.setTimeout(() => setPeekDismissed(false), 700);
-    }, 22_000);
-    return () => clearInterval(id);
-  }, [dismissed]);
-
-  useEffect(() => {
-    if (dismissed || isMobile) return;
-    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
-
-    let rafId = 0;
-    const pending = { x: 0, y: 0, dirty: false };
-
-    const flush = () => {
-      rafId = 0;
-      if (!pending.dirty) return;
-      pending.dirty = false;
-      setLean({ x: pending.x, y: pending.y });
-    };
-
-    const onMove = (e: MouseEvent) => {
-      const vw = window.innerWidth;
-      const vh = window.innerHeight;
-      const nx = (e.clientX / vw - 0.5) * 2;
-      const ny = (e.clientY / vh - 0.5) * 2;
-      pending.x = Math.round(nx * 5);
-      pending.y = Math.round(ny * 4);
-      pending.dirty = true;
-      if (rafId === 0) {
-        rafId = window.requestAnimationFrame(flush);
-      }
-    };
-
-    window.addEventListener("mousemove", onMove, { passive: true });
-    return () => {
-      window.removeEventListener("mousemove", onMove);
-      if (rafId !== 0) window.cancelAnimationFrame(rafId);
-    };
-  }, [dismissed, isMobile]);
+  useOrboLean(dismissed, isMobile, setLean);
 
   const scheduleHideBubble = useCallback((ms: number) => {
     if (displayTimerRef.current) clearTimeout(displayTimerRef.current);
@@ -333,11 +115,11 @@ export function AiBuddy() {
     setOrbMood("neutral");
     setOrbIdleDrowsy(false);
     try {
-      sessionStorage.setItem(STORAGE_KEY, "true");
+      sessionStorage.setItem(ORBO_DISMISSED_STORAGE_KEY, "true");
     } catch {
       /* private mode */
     }
-  }, []);
+  }, [setDismissed]);
 
   const showComment = useCallback(
     (text: string, mood: OrbMood = "neutral") => {
@@ -351,157 +133,35 @@ export function AiBuddy() {
       setSpeaking(true);
       setOrbMood(mood);
 
-      scheduleHideBubble(DISPLAY_DURATION);
+      scheduleHideBubble(ORBO_DISPLAY_DURATION_MS);
     },
     [scheduleHideBubble],
   );
 
-  useEffect(() => {
-    if (!isCvPage) return;
-
-    const handleCvRoleChange = (event: Event) => {
-      const detail = (event as CustomEvent<{ role?: CvReaderRole }>).detail;
-      const nextRole = detail?.role;
-      if (!nextRole) return;
-
-      cvRoleRef.current = nextRole;
-      cvSeenSignalsRef.current.clear();
-      cvDwellShownRef.current.clear();
-      cvHireNudgeShownRef.current = false;
-
-      if (!dismissed) {
-        showComment(pickRandom(CV_ROLE_CHANGE_COMMENTS[nextRole]));
-      }
-    };
-
-    window.addEventListener(ORBO_CV_ROLE_CHANGE_EVENT, handleCvRoleChange);
-    return () => window.removeEventListener(ORBO_CV_ROLE_CHANGE_EVENT, handleCvRoleChange);
-  }, [dismissed, isCvPage, showComment]);
-
-  useEffect(() => {
-    if (dismissed || !isCvPage) return;
-
-    const seen = new Set<string>();
-    const elements = document.querySelectorAll<HTMLElement>("[data-orbo-cv]");
-    if (!elements.length) return;
-
-    let debounceTimer: ReturnType<typeof setTimeout> | null = null;
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        for (const entry of entries) {
-          if (!entry.isIntersecting) continue;
-          const key = (entry.target as HTMLElement).dataset.orboCv;
-          if (!key || seen.has(key)) continue;
-
-          seen.add(key);
-          if (debounceTimer) clearTimeout(debounceTimer);
-          debounceTimer = setTimeout(() => {
-            const c = getCvSectionComment(key, cvRoleRef.current);
-            if (c) showComment(c);
-          }, 800);
-        }
-      },
-      { threshold: 0.4 },
-    );
-
-    elements.forEach((el) => observer.observe(el));
-    return () => {
-      observer.disconnect();
-      if (debounceTimer) clearTimeout(debounceTimer);
-    };
-  }, [dismissed, isCvPage, showComment]);
-
-  useEffect(() => {
-    if (dismissed || !isCvPage) return;
-
-    const elements = document.querySelectorAll<HTMLElement>("[data-orbo-cv]");
-    if (!elements.length) return;
-
-    let activeSectionId: string | null = null;
-    let dwellTimer: ReturnType<typeof setTimeout> | null = null;
-
-    const scheduleDwell = (sectionId: string) => {
-      if (dwellTimer) clearTimeout(dwellTimer);
-      if (cvDwellShownRef.current.has(sectionId)) return;
-
-      dwellTimer = setTimeout(() => {
-        if (activeSectionId !== sectionId || cvDwellShownRef.current.has(sectionId)) return;
-
-        const role = cvRoleRef.current;
-        const focusSections = CV_ROLE_FOCUS_SECTIONS[role];
-        const comments = focusSections.has(sectionId) ? CV_ROLE_DWELL_COMMENTS[role] : null;
-
-        if (!comments?.length) return;
-        cvDwellShownRef.current.add(sectionId);
-        showComment(pickRandom(comments));
-      }, 9000);
-    };
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        const visible = entries
-          .filter((entry) => entry.isIntersecting)
-          .sort((a, b) => b.intersectionRatio - a.intersectionRatio)[0];
-
-        if (!visible) return;
-        const sectionId = (visible.target as HTMLElement).dataset.orboCv;
-        if (!sectionId) return;
-
-        activeSectionId = sectionId;
-        scheduleDwell(sectionId);
-      },
-      { threshold: [0.35, 0.5, 0.75] },
-    );
-
-    elements.forEach((el) => observer.observe(el));
-    return () => {
-      observer.disconnect();
-      if (dwellTimer) clearTimeout(dwellTimer);
-    };
-  }, [dismissed, isCvPage, showComment]);
-
-  useEffect(() => {
-    if (dismissed || !isCvPage) return;
-
-    const elements = document.querySelectorAll<HTMLElement>("[data-orbo-cv]");
-    if (!elements.length) return;
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        for (const entry of entries) {
-          if (!entry.isIntersecting) continue;
-          const sectionId = (entry.target as HTMLElement).dataset.orboCv;
-          const role = cvRoleRef.current;
-          if (!sectionId || !CV_ROLE_SIGNAL_SECTIONS[role].has(sectionId)) continue;
-
-          cvSeenSignalsRef.current.add(sectionId);
-          if (cvHireNudgeShownRef.current || cvSeenSignalsRef.current.size < 3) continue;
-
-          cvHireNudgeShownRef.current = true;
-          if (hireNudgeTimerRef.current !== null) window.clearTimeout(hireNudgeTimerRef.current);
-          hireNudgeTimerRef.current = window.setTimeout(() => {
-            hireNudgeTimerRef.current = null;
-            showComment(pickRandom(CV_ROLE_HIRE_NUDGES[role]));
-          }, 1400);
-          break;
-        }
-      },
-      { threshold: 0.55 },
-    );
-
-    elements.forEach((el) => observer.observe(el));
-    return () => {
-      observer.disconnect();
-      if (hireNudgeTimerRef.current !== null) {
-        window.clearTimeout(hireNudgeTimerRef.current);
-        hireNudgeTimerRef.current = null;
-      }
-    };
-  }, [dismissed, isCvPage, showComment]);
-
   const requestComment = useCallback(
-    async (sectionId: string) => {
+    async (sectionId: string, options?: { bypassVisibility?: boolean }) => {
+      const bypassVisibility = options?.bypassVisibility ?? false;
+      const epochAtStart = sectionCommentEpochRef.current;
+      const el = document.getElementById(sectionId);
+
+      if (!el) {
+        logOrboDebug("drop: section element missing", { sectionId });
+        return false;
+      }
+
+      const initialVisibility = getSectionVerticalVisibilityRatio(el);
+      if (
+        !bypassVisibility &&
+        initialVisibility < MIN_SECTION_VISIBILITY_RATIO
+      ) {
+        logOrboDebug("drop: low visibility before request", {
+          sectionId,
+          visibility: initialVisibility,
+          min: MIN_SECTION_VISIBILITY_RATIO,
+        });
+        return false;
+      }
+
       if (displayTimerRef.current) clearTimeout(displayTimerRef.current);
       orboSectionPipelineRef.current = true;
       const t0 = Date.now();
@@ -511,401 +171,125 @@ export function AiBuddy() {
       setTooltipVisible(true);
       setSpeaking(true);
 
+      let didShow = false;
       try {
-        const aiComment = await getAiComment(sectionId);
+        const aiComment = await getOrboAiComment(sectionId);
+
+        if (sectionCommentEpochRef.current !== epochAtStart) {
+          logOrboDebug("drop: epoch changed after ai", {
+            sectionId,
+            epochAtStart,
+            epochNow: sectionCommentEpochRef.current,
+          });
+          return false;
+        }
+        const visibilityAfterAi = getSectionVerticalVisibilityRatio(el);
+        if (
+          !bypassVisibility &&
+          visibilityAfterAi < MIN_SECTION_VISIBILITY_RATIO
+        ) {
+          logOrboDebug("drop: low visibility after ai", {
+            sectionId,
+            visibility: visibilityAfterAi,
+            min: MIN_SECTION_VISIBILITY_RATIO,
+          });
+          return false;
+        }
+
         const text = aiComment ?? getRandomComment(sectionId);
         const elapsed = Date.now() - t0;
-        /* Нейросеть уже ответила — не тянуть «Думаю…» до 850 мс, иначе после быстрого API выглядит как два шага. */
         const minThink = aiComment != null ? 400 : ORBO_MIN_THINKING_MS;
         const pad = Math.max(0, minThink - elapsed);
         if (pad > 0) await new Promise((r) => setTimeout(r, pad));
+
+        if (sectionCommentEpochRef.current !== epochAtStart) {
+          logOrboDebug("drop: epoch changed after think pad", {
+            sectionId,
+            epochAtStart,
+            epochNow: sectionCommentEpochRef.current,
+          });
+          return false;
+        }
+        const visibilityBeforeShow = getSectionVerticalVisibilityRatio(el);
+        if (
+          !bypassVisibility &&
+          visibilityBeforeShow < MIN_SECTION_VISIBILITY_RATIO
+        ) {
+          logOrboDebug("drop: low visibility before show", {
+            sectionId,
+            visibility: visibilityBeforeShow,
+            min: MIN_SECTION_VISIBILITY_RATIO,
+          });
+          return false;
+        }
+
         showComment(text, "neutral");
+        logOrboDebug("show section comment", {
+          sectionId,
+          ai: aiComment != null,
+          elapsedMs: elapsed,
+        });
+        didShow = true;
+        return true;
       } finally {
         orboSectionPipelineRef.current = false;
         orboSuppressAmbientUntilRef.current = Date.now() + 2200;
+        if (!didShow) {
+          setIsThinking(false);
+          setTooltipVisible(false);
+          setSpeaking(false);
+          setOrbMood("neutral");
+        }
       }
+      return didShow;
     },
     [showComment],
   );
 
-  useEffect(() => {
-    if (dismissed || isCvPage) return;
-
-    const sectionIds = Object.values(SECTIONS_IDS);
-    const elements = sectionIds
-      .map((id) => document.getElementById(id))
-      .filter(Boolean) as HTMLElement[];
-    if (!elements.length) return;
-
-    const seen = new Set<string>();
-    const queue: string[] = [];
-    let processing = false;
-    let queueTimer: ReturnType<typeof setTimeout> | null = null;
-    let cancelled = false;
-
-    const processQueue = () => {
-      if (cancelled || processing || !queue.length) return;
-      processing = true;
-
-      const sectionId = queue.shift()!;
-      lastSectionRef.current = sectionId;
-      idleFiredRef.current = false;
-      tapCountRef.current = 0;
-      setOrbIdleDrowsy(false);
-
-      void (async () => {
-        try {
-          await requestComment(sectionId);
-        } finally {
-          if (cancelled) return;
-          queueTimer = setTimeout(() => {
-            processing = false;
-            processQueue();
-          }, SECTION_QUEUE_GAP_MS);
-        }
-      })();
-    };
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        for (const entry of entries) {
-          if (!entry.isIntersecting) continue;
-          const id = entry.target.id;
-          if (seen.has(id)) continue;
-          seen.add(id);
-          queue.push(id);
-        }
-        processQueue();
-      },
-      { threshold: 0.3, rootMargin: "0px 0px -8% 0px" },
-    );
-
-    elements.forEach((el) => observer.observe(el));
-    return () => {
-      cancelled = true;
-      observer.disconnect();
-      if (queueTimer) clearTimeout(queueTimer);
-    };
-  }, [dismissed, isCvPage, requestComment]);
-
-  useEffect(() => {
-    if (dismissed) return;
-
-    let lastScrollY = window.scrollY;
-    let lastScrollTime = Date.now();
-    let fastFired = false;
-    let maxY = window.scrollY;
-    let firedBack = false;
-    let firedBottom = false;
-
-    const ambientOrboOk = () =>
-      !orboSectionPipelineRef.current && Date.now() >= orboSuppressAmbientUntilRef.current;
-
-    const resetIdle = () => {
-      if (idleTimerRef.current) clearTimeout(idleTimerRef.current);
-      idleTimerRef.current = setTimeout(() => {
-        if (idleFiredRef.current || !lastSectionRef.current) return;
-        if (!ambientOrboOk()) return;
-        idleFiredRef.current = true;
-        setOrbIdleDrowsy(true);
-        showComment(pickRandom(IDLE_COMMENTS));
-      }, IDLE_DELAY);
-    };
-
-    const onScroll = () => {
-      resetIdle();
-      setOrbIdleDrowsy(false);
-
-      const now = Date.now();
-      const y = window.scrollY;
-
-      const delta = Math.abs(y - lastScrollY);
-      const elapsed = now - lastScrollTime;
-      if (elapsed > 800) {
-        const speed = delta / (elapsed / 1000);
-        if (speed > 3000 && !fastFired) {
-          if (ambientOrboOk()) {
-            fastFired = true;
-            showComment(pickRandom(FAST_SCROLL_COMMENTS));
-            window.setTimeout(() => {
-              fastFired = false;
-            }, 8000);
-          }
-        }
-        lastScrollY = y;
-        lastScrollTime = now;
-      }
-
-      if (y > maxY) {
-        maxY = y;
-        firedBack = false;
-      } else if (maxY - y > 400 && !firedBack) {
-        if (ambientOrboOk()) {
-          firedBack = true;
-          showComment(pickRandom(SCROLL_BACK_COMMENTS));
-          window.setTimeout(() => {
-            maxY = window.scrollY;
-            firedBack = false;
-          }, 10000);
-        }
-      }
-
-      if (!firedBottom && window.innerHeight + y >= document.body.scrollHeight - 100) {
-        if (ambientOrboOk()) {
-          firedBottom = true;
-          showComment(pickRandom(PAGE_BOTTOM_COMMENTS));
-        }
-      }
-    };
-
-    resetIdle();
-    window.addEventListener("scroll", onScroll, { passive: true });
-    return () => {
-      window.removeEventListener("scroll", onScroll);
-      if (idleTimerRef.current) clearTimeout(idleTimerRef.current);
-    };
-  }, [dismissed, showComment]);
-
-  useEffect(() => {
-    if (dismissed || isMobile) return;
-
-    let hoverTimer: ReturnType<typeof setTimeout> | null = null;
-    let lastTarget: Element | null = null;
-    let cursorCommented = false;
-
-    const handleMouseMove = (e: MouseEvent) => {
-      const target = document.elementFromPoint(e.clientX, e.clientY);
-      if (!target || target === lastTarget) return;
-
-      lastTarget = target;
-      cursorCommented = false;
-      if (hoverTimer) clearTimeout(hoverTimer);
-
-      if (target.closest("[data-orbo]")) return;
-      if (target.closest("[data-orbo-hero-greet]")) return;
-      if (target.closest("[data-orbo-bubble-reply]")) return;
-      if (target.closest("[data-orbo-max]")) return;
-
-      hoverTimer = setTimeout(() => {
-        if (cursorCommented) return;
-        if (orboSectionPipelineRef.current || Date.now() < orboSuppressAmbientUntilRef.current) {
-          return;
-        }
-        cursorCommented = true;
-
-        if (isCvPage) {
-          const cvItemComment = getCvItemComment(target, cvRoleRef.current);
-          if (cvItemComment) {
-            showComment(cvItemComment);
-            return;
-          }
-        }
-
-        if (target.closest("[data-orbo-impact-card]")) {
-          showComment(getImpactProjectCardHoverComment());
-          return;
-        }
-
-        const contextual = getContextualComment(target);
-        if (contextual) {
-          showComment(contextual);
-          return;
-        }
-
-        const elType = detectElementType(target);
-        const comments = CURSOR_COMMENTS[elType] ?? CURSOR_COMMENTS.generic;
-        showComment(pickRandom(comments));
-      }, CURSOR_HOVER_DELAY);
-    };
-
-    window.addEventListener("mousemove", handleMouseMove, { passive: true });
-    return () => {
-      window.removeEventListener("mousemove", handleMouseMove);
-      if (hoverTimer) clearTimeout(hoverTimer);
-    };
-  }, [dismissed, isCvPage, isMobile, showComment]);
-
-  useEffect(() => {
-    if (dismissed || !isCvPage) return;
-
-    let lastAt = 0;
-    const cooldownMs = 5000;
-
-    const handleClick = (event: MouseEvent) => {
-      const target = event.target;
-      if (!(target instanceof Element)) return;
-
-      const c = getCvActionComment(target, cvRoleRef.current);
-      if (!c) return;
-
-      const now = Date.now();
-      if (now - lastAt < cooldownMs) return;
-      lastAt = now;
-      showComment(c);
-    };
-
-    document.addEventListener("click", handleClick);
-    return () => document.removeEventListener("click", handleClick);
-  }, [dismissed, isCvPage, showComment]);
-
-  useEffect(() => {
-    if (dismissed) return;
-
-    const handleExperienceTooltip = () => {
-      showComment(pickRandom(EXPERIENCE_TOOLTIP_COMMENTS));
-    };
-
-    window.addEventListener("orbo:experience-tooltip", handleExperienceTooltip);
-    return () => {
-      window.removeEventListener("orbo:experience-tooltip", handleExperienceTooltip);
-    };
-  }, [dismissed, showComment]);
-
-  useEffect(() => {
-    if (dismissed) return;
-
-    const handleEasterEggHint = (event: Event) => {
-      const detail = (event as CustomEvent<{ message?: string }>).detail;
-      if (detail?.message) {
-        showComment(detail.message, "easter");
-      }
-    };
-
-    window.addEventListener(ORBO_EASTER_EGG_HINT_EVENT, handleEasterEggHint);
-    return () => window.removeEventListener(ORBO_EASTER_EGG_HINT_EVENT, handleEasterEggHint);
-  }, [dismissed, showComment]);
-
-  /** Привет в hero: показываем пузырь даже если Орбо свернули — пользователь явно позвал. */
-  useEffect(() => {
-    const handleHeroGreetingReply = (event: Event) => {
-      const detail = (event as CustomEvent<{ message?: string }>).detail;
-      if (!detail?.message) return;
-      setDismissed(false);
-      showComment(detail.message, "easter");
-    };
-
-    window.addEventListener(ORBO_HERO_GREETING_REPLY_EVENT, handleHeroGreetingReply);
-    return () =>
-      window.removeEventListener(ORBO_HERO_GREETING_REPLY_EVENT, handleHeroGreetingReply);
-  }, [showComment]);
-
-  useEffect(() => {
-    if (dismissed) return;
-
-    let lastAt = 0;
-    const cooldownMs = 14_000;
-
-    const handleMaxHover = () => {
-      const now = Date.now();
-      if (now - lastAt < cooldownMs) return;
-      lastAt = now;
-      showComment(pickRandom(MAX_ORBO_COMMENTS));
-    };
-
-    window.addEventListener(ORBO_MAX_HOVER_EVENT, handleMaxHover);
-    return () => window.removeEventListener(ORBO_MAX_HOVER_EVENT, handleMaxHover);
-  }, [dismissed, showComment]);
-
-  useEffect(() => {
-    if (dismissed) return;
-
-    const handleContactSpam = () => {
-      showComment(pickRandom(CONTACT_FORM_SPAM_COMMENTS));
-    };
-
-    window.addEventListener(ORBO_CONTACT_SPAM_EVENT, handleContactSpam);
-    return () => window.removeEventListener(ORBO_CONTACT_SPAM_EVENT, handleContactSpam);
-  }, [dismissed, showComment]);
-
-  useEffect(() => {
-    if (dismissed) return;
-
-    const handleCopy = () => showComment(pickRandom(COPY_TEXT_COMMENTS));
-
-    document.addEventListener("copy", handleCopy);
-    return () => document.removeEventListener("copy", handleCopy);
-  }, [dismissed, showComment]);
-
-  useEffect(() => {
-    if (dismissed) return;
-
-    const handleTheme = (e: Event) => {
-      const detail = (e as CustomEvent<{ theme: string }>).detail;
-      const comments = detail?.theme === "dark" ? THEME_DARK_COMMENTS : THEME_LIGHT_COMMENTS;
-      showComment(pickRandom(comments));
-    };
-
-    window.addEventListener("orbo:theme-switch", handleTheme);
-    return () => window.removeEventListener("orbo:theme-switch", handleTheme);
-  }, [dismissed, showComment]);
-
-  useEffect(() => {
-    if (dismissed) return;
-
-    let leftAt = 0;
-
-    const handleVisibility = () => {
-      if (document.hidden) {
-        leftAt = Date.now();
-      } else if (leftAt && Date.now() - leftAt > 3000) {
-        showComment(pickRandom(TAB_RETURN_COMMENTS));
-        leftAt = 0;
-      }
-    };
-
-    document.addEventListener("visibilitychange", handleVisibility);
-    return () => document.removeEventListener("visibilitychange", handleVisibility);
-  }, [dismissed, showComment]);
-
-  useEffect(() => {
-    if (dismissed) return;
-
-    let selectTimer: ReturnType<typeof setTimeout> | null = null;
-
-    const handleSelect = () => {
-      if (selectTimer) clearTimeout(selectTimer);
-      selectTimer = setTimeout(() => {
-        const sel = window.getSelection();
-        const selected = sel?.toString().trim() ?? "";
-        if (selected.length > 5) {
-          showComment(getSelectionComment(selected));
-        }
-      }, 1200);
-    };
-
-    document.addEventListener("selectionchange", handleSelect);
-    return () => {
-      document.removeEventListener("selectionchange", handleSelect);
-      if (selectTimer) clearTimeout(selectTimer);
-    };
-  }, [dismissed, showComment]);
-
-  useEffect(() => {
-    if (dismissed) return;
-
-    const RESIZE_KEY = "orbo-resize-hint-once";
-    let tid: number | null = null;
-
-    const onResize = () => {
-      if (tid !== null) window.clearTimeout(tid);
-      tid = window.setTimeout(() => {
-        tid = null;
-        try {
-          if (sessionStorage.getItem(RESIZE_KEY) === "1") return;
-          sessionStorage.setItem(RESIZE_KEY, "1");
-        } catch {
-          return;
-        }
-        showComment(pickRandom(RESIZE_WINDOW_COMMENTS));
-      }, 520);
-    };
-
-    window.addEventListener("resize", onResize, { passive: true });
-    return () => {
-      window.removeEventListener("resize", onResize);
-      if (tid !== null) window.clearTimeout(tid);
-    };
-  }, [dismissed, showComment]);
+  useOrboMainSections(
+    dismissed,
+    isCvPage,
+    requestComment,
+    lastSectionRef,
+    idleFiredRef,
+    tapCountRef,
+    sectionCommentEpochRef,
+    setOrbIdleDrowsy,
+  );
+
+  useOrboCvPage(
+    dismissed,
+    isCvPage,
+    showComment,
+    cvRoleRef,
+    cvSeenSignalsRef,
+    cvHireNudgeShownRef,
+    cvDwellShownRef,
+    hireNudgeTimerRef,
+  );
+
+  useOrboScroll(
+    dismissed,
+    showComment,
+    setOrbIdleDrowsy,
+    lastSectionRef,
+    idleTimerRef,
+    idleFiredRef,
+    orboSectionPipelineRef,
+    orboSuppressAmbientUntilRef,
+  );
+
+  useOrboCursorHover(
+    dismissed,
+    isMobile,
+    isCvPage,
+    showComment,
+    cvRoleRef,
+    orboSectionPipelineRef,
+    orboSuppressAmbientUntilRef,
+  );
+
+  useOrboGlobalEvents(dismissed, showComment, setDismissed);
 
   const getUniqueComment = useCallback((sectionId: string): string => {
     const comments = SECTION_COMMENTS[sectionId] ?? [];
@@ -920,7 +304,7 @@ export function AiBuddy() {
     tapResetTimerRef.current = setTimeout(() => {
       tapCountRef.current = 0;
       tapResetTimerRef.current = null;
-    }, TAP_COUNT_RESET_MS);
+    }, ORBO_TAP_COUNT_RESET_MS);
 
     tapCountRef.current += 1;
     const taps = tapCountRef.current;
@@ -949,13 +333,13 @@ export function AiBuddy() {
     setDismissed(false);
     idleFiredRef.current = false;
     try {
-      sessionStorage.removeItem(STORAGE_KEY);
+      sessionStorage.removeItem(ORBO_DISMISSED_STORAGE_KEY);
     } catch {
       /* private mode */
     }
     const section = lastSectionRef.current;
-    if (section) void requestComment(section);
-  }, [requestComment]);
+    if (section) void requestComment(section, { bypassVisibility: true });
+  }, [requestComment, setDismissed]);
 
   if (!portalReady) {
     return null;
@@ -967,7 +351,7 @@ export function AiBuddy() {
         <motion.button
           animate={peekDismissed ? { y: [0, -6, 0] } : { y: 0 }}
           aria-label="Вернуть Орбо"
-          className="focus-ring-accent group flex size-8 items-center justify-center rounded-full border border-accent/20 bg-surface/80 shadow-elevation-card backdrop-blur-sm transition-all duration-200 hover:scale-110 hover:border-accent/40 hover:shadow-[0_0_12px_color-mix(in_srgb,var(--color-accent)_25%,transparent)]"
+          className="focus-ring-accent group shadow-elevation-card flex size-8 items-center justify-center rounded-full border border-accent/20 bg-surface/80 backdrop-blur-sm transition-all duration-200 hover:scale-110 hover:border-accent/40 hover:shadow-[0_0_12px_color-mix(in_srgb,var(--color-accent)_25%,transparent)]"
           transition={{ duration: 0.55, ease: "easeOut" }}
           type="button"
           onClick={revive}
@@ -1016,7 +400,7 @@ export function AiBuddy() {
           visible={tooltipVisible}
           bubbleReply={{
             onOrboLine: (line) => showComment(line, "easter"),
-            onReplyBlur: () => scheduleHideBubble(DISPLAY_DURATION),
+            onReplyBlur: () => scheduleHideBubble(ORBO_DISPLAY_DURATION_MS),
             onReplyFocus: () => scheduleHideBubble(HERO_GREETING_BUBBLE_REPLY_FOCUS_MS),
           }}
           onDismiss={dismiss}

--- a/src/components/ai-buddy/hooks/use-orbo-bootstrap.ts
+++ b/src/components/ai-buddy/hooks/use-orbo-bootstrap.ts
@@ -1,0 +1,62 @@
+import { useEffect, useState } from "react";
+
+import { ORBO_DISMISSED_STORAGE_KEY } from "@/constants/ai-buddy";
+
+function isCapableDevice(): boolean {
+  if (typeof navigator === "undefined") return false;
+  const cores = navigator.hardwareConcurrency ?? 0;
+  const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  if (reducedMotion) return false;
+  if (cores < 4) return false;
+  if (window.innerWidth < 768) return false;
+  return true;
+}
+
+/**
+ * Портал, sessionStorage «свёрнут», флаги вьюпорта (CV / мобилка / «тяжёлый» аватар).
+ */
+export function useOrboBootstrap() {
+  const [portalReady, setPortalReady] = useState(false);
+  const [dismissed, setDismissed] = useState(true);
+  const [enhanced, setEnhanced] = useState(false);
+  const [isMobile, setIsMobile] = useState(false);
+  const [isCvPage, setIsCvPage] = useState(false);
+
+  useEffect(() => {
+    /* sessionStorage и портал недоступны при SSR; обновление после гидратации намеренное */
+    /* eslint-disable react-hooks/set-state-in-effect -- см. комментарий выше */
+    setPortalReady(true);
+    try {
+      setDismissed(sessionStorage.getItem(ORBO_DISMISSED_STORAGE_KEY) === "true");
+    } catch {
+      setDismissed(false);
+    }
+    /* eslint-enable react-hooks/set-state-in-effect */
+
+    const syncViewport = () => {
+      setEnhanced(isCapableDevice());
+      setIsMobile(window.innerWidth < 640);
+      const path = window.location.pathname.replace(/\/+$/, "") || "/";
+      const cvPath = `${process.env.NEXT_PUBLIC_BASE_PATH ?? ""}/cv`;
+      setIsCvPage(path === cvPath || path.startsWith(`${cvPath}/`));
+    };
+
+    syncViewport();
+    const mqReduce = window.matchMedia("(prefers-reduced-motion: reduce)");
+    mqReduce.addEventListener("change", syncViewport);
+    window.addEventListener("resize", syncViewport, { passive: true });
+    return () => {
+      mqReduce.removeEventListener("change", syncViewport);
+      window.removeEventListener("resize", syncViewport);
+    };
+  }, []);
+
+  return {
+    portalReady,
+    dismissed,
+    setDismissed,
+    enhanced,
+    isMobile,
+    isCvPage,
+  };
+}

--- a/src/components/ai-buddy/hooks/use-orbo-cursor-hover.ts
+++ b/src/components/ai-buddy/hooks/use-orbo-cursor-hover.ts
@@ -1,0 +1,86 @@
+import { useEffect, type MutableRefObject } from "react";
+
+import type { OrbMood } from "@/components/ai-buddy/orb-avatar";
+import {
+  CURSOR_COMMENTS,
+  CURSOR_HOVER_DELAY,
+  detectElementType,
+  getContextualComment,
+  getCvItemComment,
+  getImpactProjectCardHoverComment,
+  pickRandom,
+} from "@/components/ai-buddy/orbo-data";
+import type { CvReaderRole } from "@/constants/common";
+
+type ShowComment = (text: string, mood?: OrbMood) => void;
+
+/** Реплики по наведению курсора на типы элементов (и CV-айтемы). */
+export function useOrboCursorHover(
+  dismissed: boolean,
+  isMobile: boolean,
+  isCvPage: boolean,
+  showComment: ShowComment,
+  cvRoleRef: MutableRefObject<CvReaderRole>,
+  orboSectionPipelineRef: MutableRefObject<boolean>,
+  orboSuppressAmbientUntilRef: MutableRefObject<number>,
+) {
+  useEffect(() => {
+    if (dismissed || isMobile) return;
+
+    let hoverTimer: ReturnType<typeof setTimeout> | null = null;
+    let lastTarget: Element | null = null;
+    let cursorCommented = false;
+
+    const handleMouseMove = (e: MouseEvent) => {
+      const target = document.elementFromPoint(e.clientX, e.clientY);
+      if (!target || target === lastTarget) return;
+
+      lastTarget = target;
+      cursorCommented = false;
+      if (hoverTimer) clearTimeout(hoverTimer);
+
+      if (target.closest("[data-orbo]")) return;
+      if (target.closest("[data-orbo-hero-greet]")) return;
+      if (target.closest("[data-orbo-bubble-reply]")) return;
+      if (target.closest("[data-orbo-max]")) return;
+
+      hoverTimer = setTimeout(() => {
+        if (cursorCommented) return;
+        if (orboSectionPipelineRef.current || Date.now() < orboSuppressAmbientUntilRef.current) {
+          return;
+        }
+        cursorCommented = true;
+
+        if (isCvPage) {
+          const cvItemComment = getCvItemComment(target, cvRoleRef.current);
+          if (cvItemComment) {
+            showComment(cvItemComment);
+            return;
+          }
+        }
+
+        if (target.closest("[data-orbo-impact-card]")) {
+          showComment(getImpactProjectCardHoverComment());
+          return;
+        }
+
+        const contextual = getContextualComment(target);
+        if (contextual) {
+          showComment(contextual);
+          return;
+        }
+
+        const elType = detectElementType(target);
+        const comments = CURSOR_COMMENTS[elType] ?? CURSOR_COMMENTS.generic;
+        showComment(pickRandom(comments));
+      }, CURSOR_HOVER_DELAY);
+    };
+
+    window.addEventListener("mousemove", handleMouseMove, { passive: true });
+    return () => {
+      window.removeEventListener("mousemove", handleMouseMove);
+      if (hoverTimer) clearTimeout(hoverTimer);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- ref-объекты стабильны
+  }, [dismissed, isCvPage, isMobile, showComment]);
+}

--- a/src/components/ai-buddy/hooks/use-orbo-cv-page.ts
+++ b/src/components/ai-buddy/hooks/use-orbo-cv-page.ts
@@ -1,0 +1,197 @@
+import { useEffect, type MutableRefObject } from "react";
+
+import type { OrbMood } from "@/components/ai-buddy/orb-avatar";
+import {
+  CV_ROLE_CHANGE_COMMENTS,
+  CV_ROLE_DWELL_COMMENTS,
+  CV_ROLE_FOCUS_SECTIONS,
+  CV_ROLE_HIRE_NUDGES,
+  CV_ROLE_SIGNAL_SECTIONS,
+  getCvActionComment,
+  getCvSectionComment,
+  pickRandom,
+} from "@/components/ai-buddy/orbo-data";
+import { CV_READER_ROLES, ORBO_CV_ROLE_CHANGE_EVENT, type CvReaderRole } from "@/constants/common";
+import {
+  getSectionVerticalVisibilityRatio,
+  MIN_SECTION_VISIBILITY_RATIO,
+} from "@/utils/orbo-visibility";
+
+type ShowComment = (text: string, mood?: OrbMood) => void;
+
+/**
+ * CV: смена роли, клики по действиям, один IntersectionObserver на [data-orbo-cv]
+ * (первичный комментарий, dwell, hire-nudge).
+ */
+export function useOrboCvPage(
+  dismissed: boolean,
+  isCvPage: boolean,
+  showComment: ShowComment,
+  cvRoleRef: MutableRefObject<CvReaderRole>,
+  cvSeenSignalsRef: MutableRefObject<Set<string>>,
+  cvHireNudgeShownRef: MutableRefObject<boolean>,
+  cvDwellShownRef: MutableRefObject<Set<string>>,
+  hireNudgeTimerRef: MutableRefObject<number | null>,
+) {
+  useEffect(() => {
+    if (!isCvPage) {
+      cvRoleRef.current = CV_READER_ROLES.hr;
+      cvSeenSignalsRef.current.clear();
+      cvDwellShownRef.current.clear();
+      cvHireNudgeShownRef.current = false;
+      return;
+    }
+
+    cvSeenSignalsRef.current.clear();
+    cvDwellShownRef.current.clear();
+    cvHireNudgeShownRef.current = false;
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- ref-мутации при смене маршрута
+  }, [isCvPage]);
+
+  useEffect(() => {
+    if (!isCvPage) return;
+
+    const handleCvRoleChange = (event: Event) => {
+      const detail = (event as CustomEvent<{ role?: CvReaderRole }>).detail;
+      const nextRole = detail?.role;
+      if (!nextRole) return;
+
+      cvRoleRef.current = nextRole;
+      cvSeenSignalsRef.current.clear();
+      cvDwellShownRef.current.clear();
+      cvHireNudgeShownRef.current = false;
+
+      if (!dismissed) {
+        showComment(pickRandom(CV_ROLE_CHANGE_COMMENTS[nextRole]));
+      }
+    };
+
+    window.addEventListener(ORBO_CV_ROLE_CHANGE_EVENT, handleCvRoleChange);
+    return () => window.removeEventListener(ORBO_CV_ROLE_CHANGE_EVENT, handleCvRoleChange);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- ref-объекты стабильны
+  }, [dismissed, isCvPage, showComment]);
+
+  useEffect(() => {
+    if (dismissed || !isCvPage) return;
+
+    const elements = document.querySelectorAll<HTMLElement>("[data-orbo-cv]");
+    if (!elements.length) return;
+
+    const seen = new Set<string>();
+    let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+    let activeSectionId: string | null = null;
+    let dwellTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const scheduleDwell = (sectionId: string, targetEl: HTMLElement) => {
+      if (dwellTimer) clearTimeout(dwellTimer);
+      if (cvDwellShownRef.current.has(sectionId)) return;
+
+      dwellTimer = setTimeout(() => {
+        if (activeSectionId !== sectionId || cvDwellShownRef.current.has(sectionId)) return;
+
+        if (getSectionVerticalVisibilityRatio(targetEl) < MIN_SECTION_VISIBILITY_RATIO) {
+          return;
+        }
+
+        const role = cvRoleRef.current;
+        const focusSections = CV_ROLE_FOCUS_SECTIONS[role];
+        const comments = focusSections.has(sectionId) ? CV_ROLE_DWELL_COMMENTS[role] : null;
+
+        if (!comments?.length) return;
+        cvDwellShownRef.current.add(sectionId);
+        showComment(pickRandom(comments));
+      }, 9000);
+    };
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const intersecting = entries.filter((e) => e.isIntersecting);
+        if (!intersecting.length) return;
+
+        const role = cvRoleRef.current;
+
+        for (const entry of intersecting) {
+          if (entry.intersectionRatio < 0.55) continue;
+          const sectionId = (entry.target as HTMLElement).dataset.orboCv;
+          if (!sectionId || !CV_ROLE_SIGNAL_SECTIONS[role].has(sectionId)) continue;
+
+          cvSeenSignalsRef.current.add(sectionId);
+          if (cvHireNudgeShownRef.current || cvSeenSignalsRef.current.size < 3) continue;
+
+          cvHireNudgeShownRef.current = true;
+          if (hireNudgeTimerRef.current !== null) window.clearTimeout(hireNudgeTimerRef.current);
+          hireNudgeTimerRef.current = window.setTimeout(() => {
+            hireNudgeTimerRef.current = null;
+            showComment(pickRandom(CV_ROLE_HIRE_NUDGES[role]));
+          }, 1400);
+          break;
+        }
+
+        const visible = [...intersecting].sort(
+          (a, b) => b.intersectionRatio - a.intersectionRatio,
+        )[0];
+        if (visible) {
+          const sectionId = (visible.target as HTMLElement).dataset.orboCv;
+          if (sectionId) {
+            activeSectionId = sectionId;
+            scheduleDwell(sectionId, visible.target as HTMLElement);
+          }
+        }
+
+        for (const entry of intersecting) {
+          if (entry.intersectionRatio < 0.4) continue;
+          const el = entry.target as HTMLElement;
+          const key = el.dataset.orboCv;
+          if (!key || seen.has(key)) continue;
+
+          seen.add(key);
+          if (debounceTimer) clearTimeout(debounceTimer);
+          debounceTimer = setTimeout(() => {
+            if (getSectionVerticalVisibilityRatio(el) < MIN_SECTION_VISIBILITY_RATIO) {
+              return;
+            }
+            const c = getCvSectionComment(key, cvRoleRef.current);
+            if (c) showComment(c);
+          }, 800);
+        }
+      },
+      { threshold: [0.35, 0.4, 0.5, 0.55, 0.75] },
+    );
+
+    elements.forEach((el) => observer.observe(el));
+    return () => {
+      observer.disconnect();
+      if (debounceTimer) clearTimeout(debounceTimer);
+      if (dwellTimer) clearTimeout(dwellTimer);
+      if (hireNudgeTimerRef.current !== null) {
+        window.clearTimeout(hireNudgeTimerRef.current);
+        hireNudgeTimerRef.current = null;
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- ref-объекты стабильны
+  }, [dismissed, isCvPage, showComment]);
+
+  useEffect(() => {
+    if (dismissed || !isCvPage) return;
+
+    let lastAt = 0;
+    const cooldownMs = 5000;
+
+    const handleClick = (event: MouseEvent) => {
+      const target = event.target;
+      if (!(target instanceof Element)) return;
+
+      const c = getCvActionComment(target, cvRoleRef.current);
+      if (!c) return;
+
+      const now = Date.now();
+      if (now - lastAt < cooldownMs) return;
+      lastAt = now;
+      showComment(c);
+    };
+
+    document.addEventListener("click", handleClick);
+    return () => document.removeEventListener("click", handleClick);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- cvRoleRef стабилен
+  }, [dismissed, isCvPage, showComment]);
+}

--- a/src/components/ai-buddy/hooks/use-orbo-global-events.ts
+++ b/src/components/ai-buddy/hooks/use-orbo-global-events.ts
@@ -1,0 +1,188 @@
+import { useEffect, type Dispatch, type SetStateAction } from "react";
+
+import type { OrbMood } from "@/components/ai-buddy/orb-avatar";
+import {
+  CONTACT_FORM_SPAM_COMMENTS,
+  COPY_TEXT_COMMENTS,
+  EXPERIENCE_TOOLTIP_COMMENTS,
+  getSelectionComment,
+  MAX_ORBO_COMMENTS,
+  pickRandom,
+  RESIZE_WINDOW_COMMENTS,
+  TAB_RETURN_COMMENTS,
+  THEME_DARK_COMMENTS,
+  THEME_LIGHT_COMMENTS,
+} from "@/components/ai-buddy/orbo-data";
+import {
+  ORBO_CONTACT_SPAM_EVENT,
+  ORBO_EASTER_EGG_HINT_EVENT,
+  ORBO_HERO_GREETING_REPLY_EVENT,
+  ORBO_MAX_HOVER_EVENT,
+} from "@/constants/common";
+
+type ShowComment = (text: string, mood?: OrbMood) => void;
+
+/** Кастомные события, буфер, тема, вкладка, ресайз, выделение. */
+export function useOrboGlobalEvents(
+  dismissed: boolean,
+  showComment: ShowComment,
+  setDismissed: Dispatch<SetStateAction<boolean>>,
+) {
+  useEffect(() => {
+    if (dismissed) return;
+
+    const handleExperienceTooltip = () => {
+      showComment(pickRandom(EXPERIENCE_TOOLTIP_COMMENTS));
+    };
+
+    window.addEventListener("orbo:experience-tooltip", handleExperienceTooltip);
+    return () => {
+      window.removeEventListener("orbo:experience-tooltip", handleExperienceTooltip);
+    };
+  }, [dismissed, showComment]);
+
+  useEffect(() => {
+    if (dismissed) return;
+
+    const handleEasterEggHint = (event: Event) => {
+      const detail = (event as CustomEvent<{ message?: string }>).detail;
+      if (detail?.message) {
+        showComment(detail.message, "easter");
+      }
+    };
+
+    window.addEventListener(ORBO_EASTER_EGG_HINT_EVENT, handleEasterEggHint);
+    return () => window.removeEventListener(ORBO_EASTER_EGG_HINT_EVENT, handleEasterEggHint);
+  }, [dismissed, showComment]);
+
+  useEffect(() => {
+    const handleHeroGreetingReply = (event: Event) => {
+      const detail = (event as CustomEvent<{ message?: string }>).detail;
+      if (!detail?.message) return;
+      setDismissed(false);
+      showComment(detail.message, "easter");
+    };
+
+    window.addEventListener(ORBO_HERO_GREETING_REPLY_EVENT, handleHeroGreetingReply);
+    return () =>
+      window.removeEventListener(ORBO_HERO_GREETING_REPLY_EVENT, handleHeroGreetingReply);
+  }, [showComment, setDismissed]);
+
+  useEffect(() => {
+    if (dismissed) return;
+
+    let lastAt = 0;
+    const cooldownMs = 14_000;
+
+    const handleMaxHover = () => {
+      const now = Date.now();
+      if (now - lastAt < cooldownMs) return;
+      lastAt = now;
+      showComment(pickRandom(MAX_ORBO_COMMENTS));
+    };
+
+    window.addEventListener(ORBO_MAX_HOVER_EVENT, handleMaxHover);
+    return () => window.removeEventListener(ORBO_MAX_HOVER_EVENT, handleMaxHover);
+  }, [dismissed, showComment]);
+
+  useEffect(() => {
+    if (dismissed) return;
+
+    const handleContactSpam = () => {
+      showComment(pickRandom(CONTACT_FORM_SPAM_COMMENTS));
+    };
+
+    window.addEventListener(ORBO_CONTACT_SPAM_EVENT, handleContactSpam);
+    return () => window.removeEventListener(ORBO_CONTACT_SPAM_EVENT, handleContactSpam);
+  }, [dismissed, showComment]);
+
+  useEffect(() => {
+    if (dismissed) return;
+
+    const handleCopy = () => showComment(pickRandom(COPY_TEXT_COMMENTS));
+
+    document.addEventListener("copy", handleCopy);
+    return () => document.removeEventListener("copy", handleCopy);
+  }, [dismissed, showComment]);
+
+  useEffect(() => {
+    if (dismissed) return;
+
+    const handleTheme = (e: Event) => {
+      const detail = (e as CustomEvent<{ theme: string }>).detail;
+      const comments = detail?.theme === "dark" ? THEME_DARK_COMMENTS : THEME_LIGHT_COMMENTS;
+      showComment(pickRandom(comments));
+    };
+
+    window.addEventListener("orbo:theme-switch", handleTheme);
+    return () => window.removeEventListener("orbo:theme-switch", handleTheme);
+  }, [dismissed, showComment]);
+
+  useEffect(() => {
+    if (dismissed) return;
+
+    let leftAt = 0;
+
+    const handleVisibility = () => {
+      if (document.hidden) {
+        leftAt = Date.now();
+      } else if (leftAt && Date.now() - leftAt > 3000) {
+        showComment(pickRandom(TAB_RETURN_COMMENTS));
+        leftAt = 0;
+      }
+    };
+
+    document.addEventListener("visibilitychange", handleVisibility);
+    return () => document.removeEventListener("visibilitychange", handleVisibility);
+  }, [dismissed, showComment]);
+
+  useEffect(() => {
+    if (dismissed) return;
+
+    let selectTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const handleSelect = () => {
+      if (selectTimer) clearTimeout(selectTimer);
+      selectTimer = setTimeout(() => {
+        const sel = window.getSelection();
+        const selected = sel?.toString().trim() ?? "";
+        if (selected.length > 5) {
+          showComment(getSelectionComment(selected));
+        }
+      }, 1200);
+    };
+
+    document.addEventListener("selectionchange", handleSelect);
+    return () => {
+      document.removeEventListener("selectionchange", handleSelect);
+      if (selectTimer) clearTimeout(selectTimer);
+    };
+  }, [dismissed, showComment]);
+
+  useEffect(() => {
+    if (dismissed) return;
+
+    const RESIZE_KEY = "orbo-resize-hint-once";
+    let tid: number | null = null;
+
+    const onResize = () => {
+      if (tid !== null) window.clearTimeout(tid);
+      tid = window.setTimeout(() => {
+        tid = null;
+        try {
+          if (sessionStorage.getItem(RESIZE_KEY) === "1") return;
+          sessionStorage.setItem(RESIZE_KEY, "1");
+        } catch {
+          return;
+        }
+        showComment(pickRandom(RESIZE_WINDOW_COMMENTS));
+      }, 520);
+    };
+
+    window.addEventListener("resize", onResize, { passive: true });
+    return () => {
+      window.removeEventListener("resize", onResize);
+      if (tid !== null) window.clearTimeout(tid);
+    };
+  }, [dismissed, showComment]);
+}

--- a/src/components/ai-buddy/hooks/use-orbo-lean.ts
+++ b/src/components/ai-buddy/hooks/use-orbo-lean.ts
@@ -1,0 +1,42 @@
+import { useEffect, type Dispatch, type SetStateAction } from "react";
+
+/** Лёгкий наклон аватора за курсором (только десктоп, виджет развёрнут). */
+export function useOrboLean(
+  dismissed: boolean,
+  isMobile: boolean,
+  setLean: Dispatch<SetStateAction<{ x: number; y: number }>>,
+) {
+  useEffect(() => {
+    if (dismissed || isMobile) return;
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+
+    let rafId = 0;
+    const pending = { x: 0, y: 0, dirty: false };
+
+    const flush = () => {
+      rafId = 0;
+      if (!pending.dirty) return;
+      pending.dirty = false;
+      setLean({ x: pending.x, y: pending.y });
+    };
+
+    const onMove = (e: MouseEvent) => {
+      const vw = window.innerWidth;
+      const vh = window.innerHeight;
+      const nx = (e.clientX / vw - 0.5) * 2;
+      const ny = (e.clientY / vh - 0.5) * 2;
+      pending.x = Math.round(nx * 5);
+      pending.y = Math.round(ny * 4);
+      pending.dirty = true;
+      if (rafId === 0) {
+        rafId = window.requestAnimationFrame(flush);
+      }
+    };
+
+    window.addEventListener("mousemove", onMove, { passive: true });
+    return () => {
+      window.removeEventListener("mousemove", onMove);
+      if (rafId !== 0) window.cancelAnimationFrame(rafId);
+    };
+  }, [dismissed, isMobile, setLean]);
+}

--- a/src/components/ai-buddy/hooks/use-orbo-main-sections.ts
+++ b/src/components/ai-buddy/hooks/use-orbo-main-sections.ts
@@ -1,0 +1,102 @@
+import { useEffect, type MutableRefObject } from "react";
+
+import { ORBO_SECTION_QUEUE_GAP_MS } from "@/constants/ai-buddy";
+import { SECTIONS_IDS } from "@/constants/common";
+import { logOrboDebug } from "@/utils/orbo-debug";
+
+type RequestComment = (sectionId: string) => Promise<boolean>;
+
+/**
+ * Главная (не CV): очередь секций по viewport + инкремент epoch для отмены устаревших ответов.
+ */
+export function useOrboMainSections(
+  dismissed: boolean,
+  isCvPage: boolean,
+  requestComment: RequestComment,
+  lastSectionRef: MutableRefObject<string | null>,
+  idleFiredRef: MutableRefObject<boolean>,
+  tapCountRef: MutableRefObject<number>,
+  sectionCommentEpochRef: MutableRefObject<number>,
+  setOrbIdleDrowsy: (v: boolean) => void,
+) {
+  useEffect(() => {
+    if (dismissed || isCvPage) return;
+
+    const sectionIds = Object.values(SECTIONS_IDS);
+    const elements = sectionIds
+      .map((id) => document.getElementById(id))
+      .filter(Boolean) as HTMLElement[];
+    if (!elements.length) return;
+
+    const seen = new Set<string>();
+    const queue: string[] = [];
+    let processing = false;
+    let queueTimer: ReturnType<typeof setTimeout> | null = null;
+    let cancelled = false;
+
+    const processQueue = () => {
+      if (cancelled || processing || !queue.length) return;
+      processing = true;
+
+      const sectionId = queue.shift()!;
+      logOrboDebug("process queue", { sectionId, queueLeft: queue.length });
+      lastSectionRef.current = sectionId;
+      idleFiredRef.current = false;
+      tapCountRef.current = 0;
+      setOrbIdleDrowsy(false);
+
+      void (async () => {
+        let nextDelay = ORBO_SECTION_QUEUE_GAP_MS;
+        try {
+          const shown = await requestComment(sectionId);
+          nextDelay = shown ? ORBO_SECTION_QUEUE_GAP_MS : 180;
+          logOrboDebug("request done", { sectionId, shown, nextDelay });
+        } finally {
+          if (cancelled) return;
+          queueTimer = setTimeout(() => {
+            processing = false;
+            processQueue();
+          }, nextDelay);
+        }
+      })();
+    };
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const newcomers = entries
+          .filter((entry) => entry.isIntersecting)
+          .map((entry) => {
+            const target = entry.target as HTMLElement;
+            return { id: target.id, ratio: entry.intersectionRatio };
+          })
+          .filter((item) => item.id && !seen.has(item.id));
+
+        if (!newcomers.length) {
+          return;
+        }
+
+        const best = [...newcomers].sort((a, b) => b.ratio - a.ratio)[0]!;
+        seen.add(best.id);
+        sectionCommentEpochRef.current += 1;
+        /* Хвост очереди всегда заменяем на последнюю релевантную секцию. */
+        queue.length = 0;
+        queue.push(best.id);
+        logOrboDebug("enqueue best section", {
+          sectionId: best.id,
+          ratio: best.ratio,
+          epoch: sectionCommentEpochRef.current,
+        });
+        processQueue();
+      },
+      { threshold: 0.3, rootMargin: "0px 0px -8% 0px" },
+    );
+
+    elements.forEach((el) => observer.observe(el));
+    return () => {
+      cancelled = true;
+      observer.disconnect();
+      if (queueTimer) clearTimeout(queueTimer);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- ref-объекты стабильны
+  }, [dismissed, isCvPage, requestComment]);
+}

--- a/src/components/ai-buddy/hooks/use-orbo-peek.ts
+++ b/src/components/ai-buddy/hooks/use-orbo-peek.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from "react";
+
+/** Подмигивание кнопки «вернуть Орбо», когда виджет свернут. */
+export function useOrboPeek(dismissed: boolean) {
+  const [peekDismissed, setPeekDismissed] = useState(false);
+
+  useEffect(() => {
+    if (!dismissed) return;
+    const id = window.setInterval(() => {
+      setPeekDismissed(true);
+      window.setTimeout(() => setPeekDismissed(false), 700);
+    }, 22_000);
+    return () => clearInterval(id);
+  }, [dismissed]);
+
+  return peekDismissed;
+}

--- a/src/components/ai-buddy/hooks/use-orbo-scroll.ts
+++ b/src/components/ai-buddy/hooks/use-orbo-scroll.ts
@@ -1,0 +1,105 @@
+import { useEffect, type MutableRefObject } from "react";
+
+import type { OrbMood } from "@/components/ai-buddy/orb-avatar";
+import {
+  FAST_SCROLL_COMMENTS,
+  IDLE_COMMENTS,
+  PAGE_BOTTOM_COMMENTS,
+  pickRandom,
+  SCROLL_BACK_COMMENTS,
+} from "@/components/ai-buddy/orbo-data";
+import { ORBO_IDLE_DELAY_MS } from "@/constants/ai-buddy";
+
+type ShowComment = (text: string, mood?: OrbMood) => void;
+
+/** Idle после скролла, быстрый скролл, откат вверх, низ страницы. */
+export function useOrboScroll(
+  dismissed: boolean,
+  showComment: ShowComment,
+  setOrbIdleDrowsy: (v: boolean) => void,
+  lastSectionRef: MutableRefObject<string | null>,
+  idleTimerRef: MutableRefObject<ReturnType<typeof setTimeout> | null>,
+  idleFiredRef: MutableRefObject<boolean>,
+  orboSectionPipelineRef: MutableRefObject<boolean>,
+  orboSuppressAmbientUntilRef: MutableRefObject<number>,
+) {
+  useEffect(() => {
+    if (dismissed) return;
+
+    let lastScrollY = window.scrollY;
+    let lastScrollTime = Date.now();
+    let fastFired = false;
+    let maxY = window.scrollY;
+    let firedBack = false;
+    let firedBottom = false;
+
+    const ambientOrboOk = () =>
+      !orboSectionPipelineRef.current && Date.now() >= orboSuppressAmbientUntilRef.current;
+
+    const resetIdle = () => {
+      if (idleTimerRef.current) clearTimeout(idleTimerRef.current);
+      idleTimerRef.current = setTimeout(() => {
+        if (idleFiredRef.current || !lastSectionRef.current) return;
+        if (!ambientOrboOk()) return;
+        idleFiredRef.current = true;
+        setOrbIdleDrowsy(true);
+        showComment(pickRandom(IDLE_COMMENTS));
+      }, ORBO_IDLE_DELAY_MS);
+    };
+
+    const onScroll = () => {
+      resetIdle();
+      setOrbIdleDrowsy(false);
+
+      const now = Date.now();
+      const y = window.scrollY;
+
+      const delta = Math.abs(y - lastScrollY);
+      const elapsed = now - lastScrollTime;
+      if (elapsed > 800) {
+        const speed = delta / (elapsed / 1000);
+        if (speed > 3000 && !fastFired) {
+          if (ambientOrboOk()) {
+            fastFired = true;
+            showComment(pickRandom(FAST_SCROLL_COMMENTS));
+            window.setTimeout(() => {
+              fastFired = false;
+            }, 8000);
+          }
+        }
+        lastScrollY = y;
+        lastScrollTime = now;
+      }
+
+      if (y > maxY) {
+        maxY = y;
+        firedBack = false;
+      } else if (maxY - y > 400 && !firedBack) {
+        if (ambientOrboOk()) {
+          firedBack = true;
+          showComment(pickRandom(SCROLL_BACK_COMMENTS));
+          window.setTimeout(() => {
+            maxY = window.scrollY;
+            firedBack = false;
+          }, 10000);
+        }
+      }
+
+      if (!firedBottom && window.innerHeight + y >= document.body.scrollHeight - 100) {
+        if (ambientOrboOk()) {
+          firedBottom = true;
+          showComment(pickRandom(PAGE_BOTTOM_COMMENTS));
+        }
+      }
+    };
+
+    resetIdle();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      if (idleTimerRef.current) clearTimeout(idleTimerRef.current);
+    };
+    // ref-объекты стабильны — не включаем в deps, чтобы не дублировать подписки
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- см. выше
+  }, [dismissed, showComment, setOrbIdleDrowsy]);
+}

--- a/src/components/ai-buddy/orbo-bubble-reply.tsx
+++ b/src/components/ai-buddy/orbo-bubble-reply.tsx
@@ -148,7 +148,7 @@ export function OrboBubbleReply({ onOrboLine, onFieldFocus, onFieldBlur }: OrboB
     "min-w-0 flex-1 rounded-lg border border-border/45 bg-background/35 py-1.5 pr-2 pl-2 text-xs text-foreground outline-none placeholder:text-muted/75 focus:border-accent/50 focus:ring-1 focus:ring-accent/20 dark:bg-surface/30";
 
   return (
-    <div data-orbo-bubble-reply className="mt-3 border-border/35 border-t pt-3">
+    <div data-orbo-bubble-reply className="mt-3 border-t border-border/35 pt-3">
       <p className="mb-1.5 text-[10px] font-medium tracking-wide text-muted">Ответить Орбо</p>
       <form className="relative" onSubmit={onSubmit}>
         <div aria-hidden="true" className="contact-form-honeypot-text">

--- a/src/components/hero/hero-greeting-reply.tsx
+++ b/src/components/hero/hero-greeting-reply.tsx
@@ -177,9 +177,9 @@ export function HeroGreetingReply() {
 
   return (
     <div data-orbo-hero-greet className="w-full">
-      <div className="relative z-10 flex flex-col items-center gap-2 md:items-start">
-        <p className="hero-greet-cyber-row inline-flex w-full max-w-full flex-wrap items-center justify-center gap-x-2 gap-y-1 text-pretty md:justify-start md:text-left">
-          <span className="hero-greet-cyber-soft text-sm font-semibold tracking-[0.2em] text-accent-secondary uppercase">
+      <div className="relative z-10 isolate flex flex-col items-center gap-2 md:items-start">
+        <p className="hero-greet-cyber-row mx-auto inline-flex w-fit max-w-full flex-wrap items-center justify-center gap-x-2 gap-y-1 text-pretty md:mx-0 md:justify-start md:text-left">
+          <span className="hero-greet-cyber-soft text-sm font-semibold tracking-[0.12em] text-accent-secondary uppercase sm:tracking-[0.18em] md:tracking-[0.2em]">
             Привет! Меня зовут
           </span>
           <button

--- a/src/components/hero/hero.tsx
+++ b/src/components/hero/hero.tsx
@@ -161,7 +161,7 @@ export const Hero = () => {
           </motion.div>
 
           <motion.h1
-            className={`relative z-0 mt-3 w-full text-center text-5xl font-extrabold tracking-[0.04em] sm:text-6xl md:w-auto md:text-left lg:text-7xl ${heroDisplay.className}`}
+            className={`relative z-0 mt-5 w-full text-center text-5xl font-extrabold tracking-[0.04em] sm:mt-4 sm:text-6xl md:w-auto md:text-left lg:text-7xl ${heroDisplay.className}`}
             variants={itemVariants}
           >
             <span className="hero-cyber-title-wrap">

--- a/src/constants/ai-buddy.ts
+++ b/src/constants/ai-buddy.ts
@@ -1,0 +1,9 @@
+/** sessionStorage: пользователь свернул виджет Орбо. */
+export const ORBO_DISMISSED_STORAGE_KEY = "ai-buddy-dismissed";
+
+export const ORBO_DISPLAY_DURATION_MS = 6000;
+export const ORBO_SECTION_QUEUE_GAP_MS = ORBO_DISPLAY_DURATION_MS + 2800;
+export const ORBO_MIN_THINKING_MS = 850;
+export const ORBO_IDLE_DELAY_MS = 30_000;
+export const ORBO_TAP_COUNT_RESET_MS = 15_000;
+export const ORBO_AI_TIMEOUT_MS = 3000;

--- a/src/utils/orbo-ai-comment.ts
+++ b/src/utils/orbo-ai-comment.ts
@@ -1,0 +1,86 @@
+import { AI_PROMPT_TEMPLATE, SECTION_NAMES } from "@/components/ai-buddy/orbo-data";
+import { ORBO_AI_TIMEOUT_MS } from "@/constants/ai-buddy";
+import {
+  getOpenRouterApiKey,
+  ORBO_OPENROUTER_COOLDOWN_MS,
+  ORBO_OPENROUTER_MAX_FALLBACK_ATTEMPTS,
+} from "@/constants/contact-form";
+import { openRouterChatCompletion } from "@/utils/openrouter-client";
+import { withOrboOpenRouterSlot } from "@/utils/orbo-openrouter-mutex";
+
+let orboOpenRouterLastAttemptAt = 0;
+
+export async function getOrboAiComment(sectionId: string): Promise<string | null> {
+  const sectionName = SECTION_NAMES[sectionId] ?? sectionId;
+  const prompt = AI_PROMPT_TEMPLATE(sectionName);
+
+  if (getOpenRouterApiKey()) {
+    const fromOpenRouter = await withOrboOpenRouterSlot(async () => {
+      const now = Date.now();
+      if (now - orboOpenRouterLastAttemptAt < ORBO_OPENROUTER_COOLDOWN_MS) {
+        return null;
+      }
+      orboOpenRouterLastAttemptAt = Date.now();
+
+      const ac = new AbortController();
+      const t = window.setTimeout(() => ac.abort(), 12_000);
+      try {
+        const or = await openRouterChatCompletion({
+          userContent: prompt,
+          maxTokens: 120,
+          temperature: 0.55,
+          xTitle: "per0w.space - Orbo",
+          signal: ac.signal,
+          maxFallbackAttempts: ORBO_OPENROUTER_MAX_FALLBACK_ATTEMPTS,
+        });
+        if (or.ok) {
+          const line = or.text.replace(/\s+/g, " ").trim().slice(0, 280);
+          return line.length > 0 ? line : null;
+        }
+      } catch {
+        /* падаем на встроенную модель Chrome */
+      } finally {
+        window.clearTimeout(t);
+      }
+      return null;
+    });
+    if (fromOpenRouter) return fromOpenRouter;
+  }
+
+  try {
+    if (typeof LanguageModel === "undefined") return null;
+
+    const availability = await LanguageModel.availability();
+    if (availability === "unavailable") return null;
+
+    const createPromise = LanguageModel.create();
+    try {
+      const session = await Promise.race([
+        createPromise,
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error("timeout")), ORBO_AI_TIMEOUT_MS),
+        ),
+      ]);
+      try {
+        const result = await session.prompt(prompt);
+        return result?.trim() || null;
+      } finally {
+        session.destroy();
+      }
+    } catch {
+      /* Таймаут гонки: create() всё равно может завершиться — обязательно destroy. */
+      void createPromise
+        .then((s) => {
+          try {
+            s.destroy();
+          } catch {
+            /* сессия уже закрыта */
+          }
+        })
+        .catch(() => {});
+      return null;
+    }
+  } catch {
+    return null;
+  }
+}

--- a/src/utils/orbo-debug.ts
+++ b/src/utils/orbo-debug.ts
@@ -1,0 +1,20 @@
+const ORBO_DEBUG_KEY = "orbo:debug";
+
+function isOrboDebugEnabled(): boolean {
+  if (typeof window === "undefined") return false;
+  return window.localStorage.getItem(ORBO_DEBUG_KEY) === "1";
+}
+
+/**
+ * Локальный debug для Орбо: включается только вручную через localStorage.
+ * Пример:
+ * localStorage.setItem("orbo:debug", "1")
+ */
+export function logOrboDebug(message: string, meta?: Record<string, unknown>) {
+  if (!isOrboDebugEnabled()) return;
+  if (meta) {
+    console.info(`[Orbo] ${message}`, meta);
+    return;
+  }
+  console.info(`[Orbo] ${message}`);
+}

--- a/src/utils/orbo-openrouter-mutex.ts
+++ b/src/utils/orbo-openrouter-mutex.ts
@@ -1,0 +1,17 @@
+/**
+ * Один активный запрос OpenRouter для Орбо: параллельные вызовы не встают в хвост промисов,
+ * а сразу получают null — дальше сработает Chrome AI или локальный fallback.
+ */
+let orboOpenRouterLocked = false;
+
+export async function withOrboOpenRouterSlot<T>(fn: () => Promise<T | null>): Promise<T | null> {
+  if (orboOpenRouterLocked) {
+    return null;
+  }
+  orboOpenRouterLocked = true;
+  try {
+    return await fn();
+  } finally {
+    orboOpenRouterLocked = false;
+  }
+}

--- a/src/utils/orbo-visibility.ts
+++ b/src/utils/orbo-visibility.ts
@@ -1,0 +1,21 @@
+/**
+ * Если секция видна меньше порога — считаем, что пользователь уже «уехал» со скроллом.
+ * Учитываем и долю от высоты элемента, и долю viewport: иначе длинные блоки (опыт, проекты)
+ * при полноэкранном скролле ошибочно считались «почти невидимыми».
+ */
+export const MIN_SECTION_VISIBILITY_RATIO = 0.14;
+
+/** Доля пересечения секции с viewport по вертикали (0…1). */
+export function getSectionVerticalVisibilityRatio(el: HTMLElement): number {
+  const rect = el.getBoundingClientRect();
+  const vh = window.innerHeight;
+  const visibleTop = Math.max(0, rect.top);
+  const visibleBottom = Math.min(vh, rect.bottom);
+  const visibleHeight = Math.max(0, visibleBottom - visibleTop);
+  if (rect.height <= 0) {
+    return 0;
+  }
+  const elementRatio = visibleHeight / rect.height;
+  const viewportRatio = vh > 0 ? visibleHeight / vh : 0;
+  return Math.max(elementRatio, viewportRatio);
+}


### PR DESCRIPTION
## Summary
- разнести логику Орбо из монолитного компонента по хукам и утилитам
- убрать устаревшие ответы при быстром скролле (epoch + проверка видимости + актуальная очередь секций)
- добавить dev-диагностику `orbo:debug` для трассировки enqueue/drop/show

## Test plan
- [x] `pnpm lint`
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm build`
- [ ] вручную: включить `localStorage.setItem('orbo:debug','1')` и проверить, что Орбо не комментирует уже пролистанные секции