### PR TITLE
feat(components): переключатель дисплейных шрифтов, кибер-hero и карусель проектов

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -149,6 +149,8 @@ body {
   font-family: var(--font-sans);
 }
 
+/* Шрифты заголовков: className из next/font на hero/Section (см. display-font-classnames.ts). data-display-font на <html> — для отладки и localStorage. */
+
 /* Карточки и панели: единая «воздушная» глубина */
 .shadow-elevation-card {
   box-shadow: var(--elevation-card);
@@ -480,9 +482,43 @@ table {
 /* Hero: имя в стиле HUD / cyberpunk — те же accent-цвета, хроматика + лёгкий скан */
 .hero-cyber-title-wrap {
   position: relative;
-  display: inline-block;
+  /* block + 100%: рамка HUD и скан тянутся на всю ширину колонки заголовка, а не только по ширине текста */
+  display: block;
+  width: 100%;
   max-width: 100%;
   line-height: 1.05;
+  /* Одна строка: иначе псевдоэлементы с attr(data-text) расходятся с переносом строки */
+  white-space: nowrap;
+  /* Изолируем блендинг: иначе screen смешивается с фоном секции и даёт «второе» имя */
+  isolation: isolate;
+}
+
+/*
+ * Hero: трекинг и fluid-кегль по data-* с <html> (DisplayFontProvider),
+ * чтобы не плодить html:is([data-display-font=…]) на каждый новый шрифт.
+ */
+html[data-hero-title-tight="true"] #hero .hero-cyber-title-wrap {
+  letter-spacing: 0.03em;
+}
+
+@media (max-width: 639px) {
+  html[data-hero-title-fluid="true"] #hero .hero-display-title {
+    font-size: clamp(1.35rem, min(7vw, 10vmin), 2.5rem);
+    letter-spacing: 0.025em;
+  }
+}
+
+@media (min-width: 640px) and (max-width: 767px) {
+  html[data-hero-title-fluid="true"] #hero .hero-display-title {
+    font-size: clamp(1.55rem, min(5.2vw, 8vmin), 3rem);
+  }
+}
+
+/* Press Start 2P: на мобилке ещё сильнее ужимаем трекинг */
+@media (max-width: 767px) {
+  html[data-hero-title-pixel="true"] #hero .hero-cyber-title-wrap {
+    letter-spacing: 0.01em;
+  }
 }
 
 /*
@@ -539,122 +575,138 @@ table {
 .hero-cyber-title-main {
   position: relative;
   z-index: 2;
-  animation: hero-cyber-main-glitch 6s ease-in-out infinite;
+  animation: hero-cyber-main-glitch 5s ease-in-out infinite;
+}
+
+.hero-cyber-title-main::before,
+.hero-cyber-title-main::after {
+  content: attr(data-text);
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  z-index: -1;
+  pointer-events: none;
+  mix-blend-mode: normal;
+  white-space: nowrap;
+  line-height: inherit;
+  font: inherit;
+  font-weight: inherit;
+  letter-spacing: inherit;
+  text-align: inherit;
+  background: none;
+  -webkit-text-fill-color: var(--color-accent);
+  color: var(--color-accent);
+  /* Псевдо-слои невидимы в покое; появляются только в момент глитч-анимации */
+  opacity: 0;
+}
+
+.hero-cyber-title-main::before {
+  animation: hero-cyber-chroma-r 4.8s ease-in-out infinite;
+}
+
+.hero-cyber-title-main::after {
+  -webkit-text-fill-color: var(--color-accent-secondary);
+  color: var(--color-accent-secondary);
+  animation: hero-cyber-chroma-c 5s ease-in-out infinite;
 }
 
 @keyframes hero-cyber-main-glitch {
   0%,
-  94%,
+  88%,
   100% {
     transform: translate(0);
     filter: none;
   }
 
-  95% {
-    transform: translate(-1px, 0.5px);
-    filter: drop-shadow(1px 0 0 color-mix(in srgb, var(--color-accent) 55%, transparent));
+  89% {
+    transform: translate(-2px, 1px);
+    filter: drop-shadow(2px 0 0 color-mix(in srgb, var(--color-accent) 72%, transparent))
+      drop-shadow(-1px 0 0 color-mix(in srgb, var(--color-accent-secondary) 45%, transparent));
   }
 
-  96.5% {
-    transform: translate(1px, -0.5px);
+  90.5% {
+    transform: translate(2px, -1px);
     filter: drop-shadow(
-      -1px 0 0 color-mix(in srgb, var(--color-accent-secondary) 55%, transparent)
+      -2px 0 0 color-mix(in srgb, var(--color-accent-secondary) 72%, transparent)
     );
   }
 
-  98% {
+  92% {
+    transform: translate(-1px, 0);
+    filter: drop-shadow(1px 0 0 color-mix(in srgb, var(--color-accent) 55%, transparent));
+  }
+
+  94% {
     transform: translate(0);
     filter: none;
   }
-}
-
-.hero-cyber-title-r,
-.hero-cyber-title-c {
-  position: absolute;
-  left: 0;
-  top: 0;
-  z-index: 0;
-  width: 100%;
-  height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  white-space: nowrap;
-  font: inherit;
-  font-weight: inherit;
-  font-size: inherit;
-  letter-spacing: inherit;
-  line-height: inherit;
-  pointer-events: none;
-}
-
-.hero-cyber-title-r {
-  color: var(--color-accent);
-  opacity: 0.32;
-  mix-blend-mode: screen;
-  animation: hero-cyber-chroma-r 5.5s ease-in-out infinite;
-}
-
-.hero-cyber-title-c {
-  color: var(--color-accent-secondary);
-  opacity: 0.28;
-  mix-blend-mode: screen;
-  animation: hero-cyber-chroma-c 5.8s ease-in-out infinite;
-}
-
-.dark .hero-cyber-title-r {
-  opacity: 0.38;
-}
-
-.dark .hero-cyber-title-c {
-  opacity: 0.34;
 }
 
 @keyframes hero-cyber-chroma-r {
   0%,
-  90%,
+  86%,
+  93%,
   100% {
-    transform: translate(-1px, 0);
+    transform: translate(0, 0);
     clip-path: inset(0 0 0 0);
+    opacity: 0;
+  }
+
+  87% {
+    opacity: 0.45;
+  }
+
+  88% {
+    transform: translate(-3px, 1px);
+    clip-path: inset(0 10% 14% 0);
+    opacity: 0.45;
+  }
+
+  90% {
+    transform: translate(3px, -1px);
+    clip-path: inset(10% 0 0 12%);
+    opacity: 0.45;
   }
 
   92% {
-    transform: translate(-4px, 1px);
-    clip-path: inset(0 8% 12% 0);
-  }
-
-  94% {
-    transform: translate(3px, -1px);
-    clip-path: inset(8% 0 0 10%);
-  }
-
-  96% {
-    transform: translate(-1px, 0);
+    transform: translate(0, 0);
     clip-path: inset(0 0 0 0);
+    opacity: 0;
   }
 }
 
 @keyframes hero-cyber-chroma-c {
   0%,
-  91%,
+  87%,
+  94%,
   100% {
-    transform: translate(1px, 0);
+    transform: translate(0, 0);
     clip-path: inset(0 0 0 0);
+    opacity: 0;
+  }
+
+  88% {
+    opacity: 0.4;
+  }
+
+  89% {
+    transform: translate(3px, -1px);
+    clip-path: inset(12% 0 0 10%);
+    opacity: 0.4;
+  }
+
+  91% {
+    transform: translate(-3px, 1px);
+    clip-path: inset(0 12% 10% 0);
+    opacity: 0.4;
   }
 
   93% {
-    transform: translate(4px, -1px);
-    clip-path: inset(10% 0 0 8%);
-  }
-
-  95% {
-    transform: translate(-3px, 1px);
-    clip-path: inset(0 10% 8% 0);
-  }
-
-  97% {
-    transform: translate(1px, 0);
+    transform: translate(0, 0);
     clip-path: inset(0 0 0 0);
+    opacity: 0;
   }
 }
 
@@ -664,16 +716,16 @@ table {
   inset: 0;
   z-index: 1;
   border-radius: 0.08em;
-  opacity: 0.07;
+  opacity: 0.06;
   background: repeating-linear-gradient(
     0deg,
     transparent,
-    transparent 1px,
-    color-mix(in srgb, var(--color-foreground) 12%, transparent) 1px,
-    color-mix(in srgb, var(--color-foreground) 12%, transparent) 2px
+    transparent 2px,
+    color-mix(in srgb, var(--color-foreground) 10%, transparent) 2px,
+    color-mix(in srgb, var(--color-foreground) 10%, transparent) 3px
   );
   mix-blend-mode: overlay;
-  animation: hero-cyber-scan-move 7s linear infinite;
+  animation: hero-cyber-scan-move 8s linear infinite;
 }
 
 @keyframes hero-cyber-scan-move {
@@ -692,8 +744,8 @@ table {
  * На md+ оставляем полный cyber-HUD.
  */
 @media (max-width: 767px) {
-  .hero-cyber-title-r,
-  .hero-cyber-title-c,
+  .hero-cyber-title-main::before,
+  .hero-cyber-title-main::after,
   .hero-cyber-scan {
     display: none !important;
   }
@@ -706,9 +758,10 @@ table {
 
   .hero-cyber-title-main {
     animation: none;
-    /* drop-shadow работает с bg-clip-text; text-shadow у «прозрачной» заливки часто не виден */
-    filter: drop-shadow(0 0 14px color-mix(in srgb, var(--color-accent) 35%, transparent))
-      drop-shadow(0 0 28px color-mix(in srgb, var(--color-accent-secondary) 18%, transparent));
+    /* drop-shadow работает с bg-clip-text; усилено, т.к. хрома на мобилке отключена */
+    filter: drop-shadow(0 0 10px color-mix(in srgb, var(--color-accent) 55%, transparent))
+      drop-shadow(0 0 22px color-mix(in srgb, var(--color-accent-secondary) 35%, transparent))
+      drop-shadow(1px 0 0 color-mix(in srgb, var(--color-accent) 25%, transparent));
   }
 }
 
@@ -1620,8 +1673,8 @@ table {
 
   .hero-cyber-hud,
   .hero-cyber-title-main,
-  .hero-cyber-title-r,
-  .hero-cyber-title-c,
+  .hero-cyber-title-main::before,
+  .hero-cyber-title-main::after,
   .hero-cyber-scan {
     animation: none !important;
   }
@@ -1714,8 +1767,8 @@ table {
   }
 
   .hero-cyber-hud,
-  .hero-cyber-title-r,
-  .hero-cyber-title-c,
+  .hero-cyber-title-main::before,
+  .hero-cyber-title-main::after,
   .hero-cyber-scan {
     display: none !important;
   }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { Footer } from "@/components/footer/footer";
 import { Header } from "@/components/header/header";
 import { Providers } from "@/components/providers/providers";
 import { MAIN_CONTENT_ID } from "@/constants/common";
+import { cosmicDisplayGoogle } from "@/fonts/cosmic-cyrillic-google";
 
 import type { Metadata } from "next";
 
@@ -60,10 +61,14 @@ export default function RootLayout({
 }>) {
   return (
     <html
-      className={cx(GeistSans.variable, GeistMono.variable)}
       data-scroll-behavior="smooth"
       lang="ru"
       suppressHydrationWarning={true}
+      className={cx(
+        GeistSans.variable,
+        GeistMono.variable,
+        ...Object.values(cosmicDisplayGoogle).map((f) => f.variable),
+      )}
     >
       <body className="xs:text-[16px] mx-auto max-w-screen-xl px-5 antialiased md:text-[18px]">
         <a className="skip-to-content" href={`#${MAIN_CONTENT_ID}`}>

--- a/src/components/display-font/display-font-context.tsx
+++ b/src/components/display-font/display-font-context.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+
+import {
+  DISPLAY_FONT_LABELS,
+  DISPLAY_FONT_STORAGE_KEY,
+  DISPLAY_FONTS,
+  displayFontIsHeroPressStartPixel,
+  displayFontNeedsHeroFluidMobile,
+  displayFontNeedsHeroTitleTight,
+  type DisplayFontId,
+  isDisplayFontId,
+} from "@/constants/display-font";
+
+type DisplayFontContextValue = {
+  id: DisplayFontId;
+  cycle: () => void;
+  label: string;
+};
+
+const DisplayFontContext = createContext<DisplayFontContextValue | null>(null);
+
+export function DisplayFontProvider({ children }: { children: ReactNode }) {
+  const [id, setId] = useState<DisplayFontId>("nasalization");
+
+  /* После гидратации подтягиваем сохранённый шрифт; на SSR остаётся первый из DISPLAY_FONTS. */
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(DISPLAY_FONT_STORAGE_KEY);
+      if (raw && isDisplayFontId(raw)) {
+        /* eslint-disable-next-line react-hooks/set-state-in-effect -- единичная синхронизация с localStorage, не цепочка рендеров */
+        setId(raw);
+      }
+    } catch {
+      /* приватный режим */
+    }
+  }, []);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.dataset.displayFont = id;
+
+    /* Атрибуты для hero в globals.css — без длинных html:is(...) по каждому шрифту */
+    if (displayFontNeedsHeroTitleTight(id)) {
+      root.dataset.heroTitleTight = "true";
+    } else {
+      delete root.dataset.heroTitleTight;
+    }
+    if (displayFontNeedsHeroFluidMobile(id)) {
+      root.dataset.heroTitleFluid = "true";
+    } else {
+      delete root.dataset.heroTitleFluid;
+    }
+    if (displayFontIsHeroPressStartPixel(id)) {
+      root.dataset.heroTitlePixel = "true";
+    } else {
+      delete root.dataset.heroTitlePixel;
+    }
+
+    try {
+      localStorage.setItem(DISPLAY_FONT_STORAGE_KEY, id);
+    } catch {
+      /* приватный режим */
+    }
+  }, [id]);
+
+  const cycle = useCallback(() => {
+    setId((prev) => {
+      const i = DISPLAY_FONTS.indexOf(prev);
+      return DISPLAY_FONTS[(i + 1) % DISPLAY_FONTS.length]!;
+    });
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      id,
+      cycle,
+      label: DISPLAY_FONT_LABELS[id],
+    }),
+    [id, cycle],
+  );
+
+  return <DisplayFontContext.Provider value={value}>{children}</DisplayFontContext.Provider>;
+}
+
+export function useDisplayFont(): DisplayFontContextValue {
+  const ctx = useContext(DisplayFontContext);
+  if (!ctx) {
+    throw new Error("useDisplayFont: оберните дерево в DisplayFontProvider");
+  }
+  return ctx;
+}

--- a/src/components/display-font/display-font-switcher.tsx
+++ b/src/components/display-font/display-font-switcher.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+import { ALargeSmall } from "lucide-react";
+
+import { useDisplayFont } from "@/components/display-font/display-font-context";
+
+const emptySubscribe = () => () => {};
+
+export function DisplayFontSwitcher() {
+  const mounted = useSyncExternalStore(emptySubscribe, () => true, () => false);
+  const { cycle, label } = useDisplayFont();
+
+  if (!mounted) {
+    return <span aria-hidden className="inline-block size-9 shrink-0" />;
+  }
+
+  return (
+    <button
+      aria-label={`Шрифт заголовков: ${label}. Нажмите, чтобы переключить`}
+      className="focus-ring-accent flex size-9 shrink-0 items-center justify-center rounded-xl text-muted transition-all duration-200 hover:bg-accent/10 hover:text-foreground"
+      title={`Шрифт заголовков: ${label}`}
+      type="button"
+      onClick={cycle}
+    >
+      <ALargeSmall aria-hidden className="size-[18px]" strokeWidth={2.25} />
+    </button>
+  );
+}

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -7,6 +7,8 @@ import Link from "next/link";
 import { AnimatePresence, motion } from "framer-motion";
 import { Mail, Menu, PanelBottom, X } from "lucide-react";
 
+import { useDisplayFont } from "@/components/display-font/display-font-context";
+import { DisplayFontSwitcher } from "@/components/display-font/display-font-switcher";
 import {
   MAX_MESSENGER_PROFILE_URL,
   ORBO_MAX_HOVER_EVENT,
@@ -16,6 +18,7 @@ import {
   PROFILE_VK_URL,
   SECTIONS_IDS,
 } from "@/constants/common";
+import { DISPLAY_FONT_CLASSNAMES } from "@/fonts/display-font-classnames";
 import { GitHubIcon, MaxMessengerIcon, TelegramIcon, VkIcon } from "@/ui/icons";
 
 import ThemeSwitcher from "../theme-switcher/theme-switcher";
@@ -97,6 +100,8 @@ function AllContactsLink({
 }
 
 export const Header = () => {
+  const { id: displayFontId } = useDisplayFont();
+  const displayFontClass = DISPLAY_FONT_CLASSNAMES[displayFontId];
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
   useEffect(() => {
@@ -175,7 +180,7 @@ export const Header = () => {
         <div className="mx-auto flex h-16 max-w-screen-xl items-center gap-2 px-3 sm:gap-3 sm:px-5">
           <Link
             aria-label="На главную, per0w.space"
-            className="focus-ring-accent min-w-0 shrink-0 rounded-md bg-linear-to-r from-accent to-accent-secondary bg-clip-text text-lg font-bold tracking-tighter text-transparent sm:text-xl"
+            className={`focus-ring-accent ${displayFontClass} min-w-0 max-w-[50vw] shrink-0 truncate rounded-md bg-linear-to-r from-accent to-accent-secondary bg-clip-text text-lg font-bold tracking-tighter text-transparent sm:max-w-none sm:text-xl`}
             href="/"
           >
             PER0W.SPACE
@@ -201,6 +206,7 @@ export const Header = () => {
           </div>
 
           <div className="flex shrink-0 items-center justify-end gap-0.5 sm:gap-1">
+            <DisplayFontSwitcher />
             <ThemeSwitcher />
 
             <div className="hidden items-center border-l border-border/60 pl-1 sm:pl-2 md:flex">

--- a/src/components/hero/hero.tsx
+++ b/src/components/hero/hero.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { Exo_2 } from "next/font/google";
 import Image from "next/image";
 import Link from "next/link";
 
@@ -16,19 +15,15 @@ import {
   Users,
 } from "lucide-react";
 
+import { useDisplayFont } from "@/components/display-font/display-font-context";
 import { SECTIONS_IDS } from "@/constants/common";
+import type { DisplayFontId } from "@/constants/display-font";
+import { DISPLAY_FONT_CLASSNAMES } from "@/fonts/display-font-classnames";
 import { ScrambleRevealText } from "@/ui/scramble-reveal/scramble-reveal";
 
 import { AvatarFrame } from "./avatar-frame";
 import { HeroGreetingReply } from "./hero-greeting-reply";
 import photo from "./photo-main.png";
-
-/** Дисплейный шрифт с кириллицей — «игровой» HUD, без смены палитры сайта */
-const heroDisplay = Exo_2({
-  subsets: ["latin", "cyrillic", "cyrillic-ext"],
-  weight: ["700", "800"],
-  display: "swap",
-});
 
 const USP_ITEMS = [
   {
@@ -137,7 +132,87 @@ function HeroServicesCta() {
   );
 }
 
+/** Fluid-кегль для стандартных (не широких) дисплейных гарнитур. */
+const HERO_TITLE_SIZE_DEFAULT =
+  "text-[clamp(1.6rem,7.5vw,2.8rem)] sm:text-[clamp(1.8rem,5.5vw,3.2rem)] md:text-[clamp(2.2rem,4vw,3.75rem)] lg:text-[clamp(2.6rem,3.2vw,4.5rem)]";
+
+/** Широкие дисплейные гарнитуры в hero — кегль по тиру (одна clamp-строка на группу). */
+const HERO_TITLE_COMPACT_IDS = [
+  "freak-show",
+  "tesla",
+  "rubik-moonrocks",
+  "good-future",
+  "stalinist-one",
+  "pinnacle",
+  "russo-one",
+  "press-start-2p",
+  "rubik-pixels",
+  "rubik-broken-fax",
+  "rubik-wet-paint",
+  "rubik-mono-one",
+] as const satisfies readonly DisplayFontId[];
+
+type HeroTitleCompactFontId = (typeof HERO_TITLE_COMPACT_IDS)[number];
+
+type HeroTitleSizeTier =
+  | "wideStandard"
+  | "decorativeRubik"
+  | "goodFuture"
+  | "stalinist"
+  | "pinnacle"
+  | "russo"
+  | "pressStart2p"
+  | "monoOne";
+
+/** Fluid clamp по тиру; строки целиком для Tailwind. */
+const HERO_TITLE_TIER_CLASSES: Record<HeroTitleSizeTier, string> = {
+  wideStandard:
+    "text-[clamp(1.3rem,min(7vw,10vmin),2.1rem)] sm:text-[clamp(1.5rem,min(5vw,8vmin),2.5rem)] md:text-[clamp(1.9rem,3.8vw,2.8rem)] lg:text-[clamp(2.2rem,3.5vw,3.25rem)]",
+  decorativeRubik:
+    "text-[clamp(1.25rem,min(7vw,10vmin),2rem)] sm:text-[clamp(1.45rem,min(5vw,8vmin),2.4rem)] md:text-[clamp(1.85rem,3.8vw,2.7rem)] lg:text-[clamp(2.1rem,3.5vw,3.1rem)]",
+  goodFuture:
+    "text-[clamp(1.35rem,min(7vw,10vmin),2.2rem)] sm:text-[clamp(1.55rem,min(5vw,8vmin),2.7rem)] md:text-[clamp(1.95rem,3.8vw,3rem)] lg:text-[clamp(2.3rem,3.5vw,3.5rem)]",
+  stalinist:
+    "text-[clamp(1.3rem,min(7vw,10vmin),2.1rem)] sm:text-[clamp(1.5rem,min(5vw,8vmin),2.5rem)] md:text-[clamp(1.9rem,3.8vw,2.85rem)] lg:text-[clamp(2.2rem,3.5vw,3.35rem)]",
+  pinnacle:
+    "text-[clamp(1.3rem,min(7vw,10vmin),2.15rem)] sm:text-[clamp(1.5rem,min(5vw,8vmin),2.6rem)] md:text-[clamp(1.9rem,3.8vw,2.9rem)] lg:text-[clamp(2.2rem,3.5vw,3.4rem)]",
+  russo:
+    "text-[clamp(1.35rem,min(7vw,10vmin),2.2rem)] sm:text-[clamp(1.55rem,min(5vw,8vmin),2.6rem)] md:text-[clamp(1.95rem,3.8vw,2.9rem)] lg:text-[clamp(2.3rem,3.5vw,3.4rem)]",
+  pressStart2p:
+    "text-[clamp(0.7rem,min(4.5vw,6vmin),1.1rem)] sm:text-[clamp(0.85rem,min(3.5vw,5.5vmin),1.5rem)] md:text-[clamp(1.1rem,2.5vw,1.75rem)] lg:text-[clamp(1.3rem,2.2vw,2rem)]",
+  monoOne:
+    "text-[clamp(1.1rem,min(6vw,8vmin),1.7rem)] sm:text-[clamp(1.3rem,min(4.5vw,7vmin),2.1rem)] md:text-[clamp(1.6rem,3.5vw,2.4rem)] lg:text-[clamp(1.9rem,3vw,2.8rem)]",
+};
+
+const HERO_TITLE_COMPACT_TIER: Record<HeroTitleCompactFontId, HeroTitleSizeTier> = {
+  "freak-show": "wideStandard",
+  tesla: "wideStandard",
+  "rubik-moonrocks": "decorativeRubik",
+  "rubik-pixels": "decorativeRubik",
+  "rubik-broken-fax": "decorativeRubik",
+  "rubik-wet-paint": "decorativeRubik",
+  "good-future": "goodFuture",
+  "stalinist-one": "stalinist",
+  pinnacle: "pinnacle",
+  "russo-one": "russo",
+  "press-start-2p": "pressStart2p",
+  "rubik-mono-one": "monoOne",
+};
+
+function isHeroTitleCompact(id: DisplayFontId): id is HeroTitleCompactFontId {
+  return (HERO_TITLE_COMPACT_IDS as readonly string[]).includes(id);
+}
+
+function getHeroTitleSizeClass(id: DisplayFontId): string {
+  if (!isHeroTitleCompact(id)) return HERO_TITLE_SIZE_DEFAULT;
+  return HERO_TITLE_TIER_CLASSES[HERO_TITLE_COMPACT_TIER[id]];
+}
+
 export const Hero = () => {
+  const { id: displayFontId } = useDisplayFont();
+  const displayFontClass = DISPLAY_FONT_CLASSNAMES[displayFontId];
+  const heroTitleSizeClass = getHeroTitleSizeClass(displayFontId);
+
   return (
     <section
       className="relative flex min-h-[85vh] items-center justify-center overflow-hidden py-16 md:py-24"
@@ -149,10 +224,10 @@ export const Hero = () => {
         className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(ellipse_80%_50%_at_50%_-20%,color-mix(in_srgb,var(--color-accent)_18%,transparent),transparent_55%),radial-gradient(ellipse_60%_40%_at_100%_50%,color-mix(in_srgb,var(--color-accent-secondary)_12%,transparent),transparent_50%),radial-gradient(ellipse_50%_35%_at_0%_80%,color-mix(in_srgb,var(--color-accent-light)_10%,transparent),transparent_45%)]"
       />
 
-      <div className="mx-auto flex max-w-screen-xl flex-col-reverse items-center gap-8 px-4 sm:px-6 md:flex-row md:items-center md:gap-12 lg:gap-14">
+      <div className="mx-auto flex w-full max-w-screen-xl min-w-0 flex-col-reverse items-center gap-8 px-4 sm:px-6 md:flex-row md:items-center md:gap-12 lg:gap-14">
         <motion.div
           animate="visible"
-          className="flex flex-col items-center text-center md:flex-1 md:items-start md:text-left"
+          className="flex w-full min-w-0 flex-col items-center text-center md:min-w-0 md:flex-1 md:items-start md:text-left"
           initial="hidden"
           variants={containerVariants}
         >
@@ -161,19 +236,16 @@ export const Hero = () => {
           </motion.div>
 
           <motion.h1
-            className={`relative z-0 mt-5 w-full text-center text-5xl font-extrabold tracking-[0.04em] sm:mt-4 sm:text-6xl md:w-auto md:text-left lg:text-7xl ${heroDisplay.className}`}
+            className={`hero-display-title ${displayFontClass} ${heroTitleSizeClass} relative z-0 mt-5 w-full max-w-full min-w-0 text-center tracking-[0.06em] sm:mt-4 md:text-left`}
             variants={itemVariants}
           >
             <span className="hero-cyber-title-wrap">
               <span aria-hidden className="hero-cyber-hud" />
-              <span aria-hidden className="hero-cyber-title-r">
-                Владимир Перов
-              </span>
-              <span aria-hidden className="hero-cyber-title-c">
-                Владимир Перов
-              </span>
               <span aria-hidden className="hero-cyber-scan" />
-              <span className="hero-cyber-title-main bg-linear-to-r from-accent via-accent-light to-accent-secondary bg-clip-text text-transparent">
+              <span
+                className="hero-cyber-title-main bg-linear-to-r from-accent via-accent-light to-accent-secondary bg-clip-text text-transparent"
+                data-text="Владимир Перов"
+              >
                 Владимир Перов
               </span>
             </span>

--- a/src/components/projects/impact-project-card.tsx
+++ b/src/components/projects/impact-project-card.tsx
@@ -28,7 +28,7 @@ export function ImpactProjectCard({ emoji, title, problem, stack, role }: Impact
 
   return (
     <article
-      className="shadow-elevation-panel hover:shadow-elevation-card flex h-full min-h-0 flex-col rounded-2xl border border-border bg-surface p-5 text-left transition-[box-shadow,border-color] duration-300 hover:border-accent/35"
+      className="shadow-elevation-panel hover:shadow-elevation-card flex h-full min-h-0 w-full min-w-0 flex-col rounded-2xl border border-border bg-surface p-5 text-left transition-[box-shadow,border-color] duration-300 hover:border-accent/35"
       data-orbo-impact-card=""
     >
       <div aria-hidden className="mb-3 text-3xl">

--- a/src/components/projects/open-project-showcase.tsx
+++ b/src/components/projects/open-project-showcase.tsx
@@ -113,7 +113,7 @@ export function OpenProjectShowcase({
 
   if (variant === "carousel") {
     return (
-      <article className={`${articleClass} flex h-full min-h-0 flex-col`}>
+      <article className={`${articleClass} flex h-full min-h-0 w-full min-w-0 flex-col`}>
         <ProjectCardMedia slides={slides} />
         {body}
       </article>

--- a/src/components/projects/projects-carousel.tsx
+++ b/src/components/projects/projects-carousel.tsx
@@ -133,18 +133,18 @@ export const ProjectsCarousel = ({
     <section
       aria-labelledby={`${regionId}-title`}
       aria-roledescription="Карусель"
-      className="relative w-full max-w-5xl px-1 sm:px-2"
+      className="relative w-full max-w-5xl px-0 sm:px-2"
     >
       <p className="sr-only" id={`${regionId}-title`}>
         {ariaLabel}. Используйте кнопки или свайп, чтобы листать.
       </p>
       <p className="mb-3 text-center text-xs text-muted sm:text-sm">{helperText}</p>
 
-      <div className="flex items-stretch gap-2 sm:gap-3">
+      <div className="flex items-stretch gap-0 sm:gap-3">
         <button
           aria-controls={`${regionId}-track`}
           aria-label="Предыдущий проект"
-          className="focus-ring-accent shadow-elevation-panel flex size-10 shrink-0 items-center justify-center self-center rounded-xl border border-border bg-surface text-muted transition-colors hover:border-accent/40 hover:text-accent disabled:pointer-events-none disabled:opacity-35 sm:size-11"
+          className="focus-ring-accent shadow-elevation-panel hidden size-10 shrink-0 items-center justify-center self-center rounded-xl border border-border bg-surface text-muted transition-colors hover:border-accent/40 hover:text-accent disabled:pointer-events-none disabled:opacity-35 sm:flex sm:size-11"
           disabled={atStart}
           type="button"
           onClick={goPrev}
@@ -152,10 +152,10 @@ export const ProjectsCarousel = ({
           <ChevronLeft aria-hidden className="size-5" />
         </button>
 
-        <div className="min-w-0 flex-1 touch-pan-x">
+        <div className="min-w-0 w-full flex-1 touch-pan-x">
           <div
             ref={scrollerRef}
-            className="flex snap-x snap-mandatory items-stretch gap-4 overflow-x-auto scroll-smooth py-2 pb-3 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+            className="flex snap-x snap-mandatory items-stretch gap-3 overflow-x-auto scroll-smooth py-2 pb-3 [-ms-overflow-style:none] [scrollbar-width:none] sm:gap-4 [&::-webkit-scrollbar]:hidden"
             id={`${regionId}-track`}
             tabIndex={0}
             onKeyDown={(e) => {
@@ -176,7 +176,7 @@ export const ProjectsCarousel = ({
         <button
           aria-controls={`${regionId}-track`}
           aria-label="Следующий проект"
-          className="focus-ring-accent shadow-elevation-panel flex size-10 shrink-0 items-center justify-center self-center rounded-xl border border-border bg-surface text-muted transition-colors hover:border-accent/40 hover:text-accent disabled:pointer-events-none disabled:opacity-35 sm:size-11"
+          className="focus-ring-accent shadow-elevation-panel hidden size-10 shrink-0 items-center justify-center self-center rounded-xl border border-border bg-surface text-muted transition-colors hover:border-accent/40 hover:text-accent disabled:pointer-events-none disabled:opacity-35 sm:flex sm:size-11"
           disabled={atEnd}
           type="button"
           onClick={goNext}

--- a/src/components/projects/projects.tsx
+++ b/src/components/projects/projects.tsx
@@ -40,10 +40,16 @@ const TRENIKA_SLIDES: ProjectCardSlide[] = [
   },
 ];
 
-/** Ширина слайда как у карточек `Card variant="carousel"` — при добавлении проектов секция не растёт по высоте. */
-const impactSlideClass = "w-[min(17.5rem,calc(100vw-5rem))] shrink-0 snap-start sm:w-72";
+/**
+ * Мобилка: ширина слайда = ширина трека (flex-basis 100%), иначе calc(100vw−…) шире ленты
+ * из‑за стрелок и вложенных px — карточки выглядели обрезанными.
+ * sm+: фиксированная ширина как у карточек карусели.
+ */
+const impactSlideClass =
+  "w-full min-w-0 max-w-full shrink-0 grow-0 basis-full snap-start sm:w-72 sm:max-w-none sm:basis-72";
 
-const openProjectSlideClass = "w-[min(19rem,calc(100vw-5rem))] shrink-0 snap-start sm:w-80";
+const openProjectSlideClass =
+  "w-full min-w-0 max-w-full shrink-0 grow-0 basis-full snap-start sm:w-80 sm:max-w-none sm:basis-80";
 
 const OPEN_PROJECTS: Array<{
   title: string;

--- a/src/components/providers/providers.tsx
+++ b/src/components/providers/providers.tsx
@@ -3,16 +3,19 @@
 import { ThemeProvider } from "next-themes";
 
 import { AiBuddyDeferred } from "@/components/ai-buddy/ai-buddy-deferred";
+import { DisplayFontProvider } from "@/components/display-font/display-font-context";
 import { HashNavigation } from "@/components/hash-navigation/hash-navigation";
 import { ParticlesBackground } from "@/components/particles/particles-background";
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <ThemeProvider enableSystem attribute="class" defaultTheme="dark">
-      <HashNavigation />
-      <ParticlesBackground />
-      <AiBuddyDeferred />
-      {children}
+      <DisplayFontProvider>
+        <HashNavigation />
+        <ParticlesBackground />
+        <AiBuddyDeferred />
+        {children}
+      </DisplayFontProvider>
     </ThemeProvider>
   );
 }

--- a/src/constants/display-font.ts
+++ b/src/constants/display-font.ts
@@ -1,0 +1,116 @@
+/** localStorage: выбор дисплейного шрифта для заголовков (hero + секции). */
+export const DISPLAY_FONT_STORAGE_KEY = "per0w-display-font";
+
+/**
+ * Дисплейные заголовки: бесплатные гарнитуры с кириллицей из Google Fonts (OFL / открытая лицензия).
+ * Первые позиции — аналоги подборки «Космические шрифты на кириллице»
+ * https://smm-design.ru/kosmicheskie-shrifty-kirillica/ ; далее — доп. техно/космос из каталога GF.
+ */
+export const DISPLAY_FONTS = [
+  "nasalization",
+  "zekton",
+  "neuropol-x",
+  "saiba-45",
+  "vivl-rail",
+  "good-future",
+  "tablon",
+  "freak-show",
+  "pinnacle",
+  "tesla",
+  "unbounded",
+  "rubik-iso",
+  "rubik-lines",
+  "rubik-moonrocks",
+  "stalinist-one",
+  "kelly-slab",
+  "russo-one",
+  "press-start-2p",
+  "exo-2",
+  "rubik-pixels",
+  "rubik-broken-fax",
+  "rubik-wet-paint",
+  "rubik-mono-one",
+] as const;
+
+export type DisplayFontId = (typeof DISPLAY_FONTS)[number];
+
+/** Подпись для aria/title: для аналогов подборки — «имя · GF»; остальные — как в каталоге Google Fonts. */
+export const DISPLAY_FONT_LABELS: Record<DisplayFontId, string> = {
+  nasalization: "Nasalization · Tektur",
+  zekton: "Zekton · Handjet",
+  "neuropol-x": "Neuropol X · Dela Gothic One",
+  "saiba-45": "Saiba-45 · Kablammo",
+  "vivl-rail": "VIVL Rail · Pixelify Sans",
+  "good-future": "Good Future · Orelega One",
+  tablon: "Tablon · Rubik Storm",
+  "freak-show": "Freak Show · Rubik Glitch",
+  pinnacle: "Pinnacle · Train One",
+  tesla: "Тесла · Ruslan Display",
+  unbounded: "Unbounded",
+  "rubik-iso": "Rubik Iso",
+  "rubik-lines": "Rubik Lines",
+  "rubik-moonrocks": "Rubik Moonrocks",
+  "stalinist-one": "Stalinist One",
+  "kelly-slab": "Kelly Slab",
+  "russo-one": "Russo One",
+  "press-start-2p": "Press Start 2P",
+  "exo-2": "Exo 2",
+  "rubik-pixels": "Rubik Pixels",
+  "rubik-broken-fax": "Rubik Broken Fax",
+  "rubik-wet-paint": "Rubik Wet Paint",
+  "rubik-mono-one": "Rubik Mono One",
+};
+
+export function isDisplayFontId(value: string): value is DisplayFontId {
+  return (DISPLAY_FONTS as readonly string[]).includes(value);
+}
+
+/**
+ * В hero без ужатого letter-spacing на .hero-cyber-title-wrap.
+ * Остальные шрифты — на <html> выставляется data-hero-title-tight (см. globals.css).
+ */
+export const DISPLAY_FONT_HERO_RELAXED_TRACKING_IDS = [
+  "nasalization",
+  "neuropol-x",
+  "saiba-45",
+  "vivl-rail",
+  "tablon",
+  "exo-2",
+] as const satisfies readonly DisplayFontId[];
+
+export function displayFontNeedsHeroTitleTight(id: DisplayFontId): boolean {
+  return !(DISPLAY_FONT_HERO_RELAXED_TRACKING_IDS as readonly string[]).includes(id);
+}
+
+/** Доп. fluid-кегль hero на узких экранах — data-hero-title-fluid. */
+export const DISPLAY_FONT_HERO_FLUID_MOBILE_IDS = [
+  "zekton",
+  "unbounded",
+  "rubik-iso",
+  "rubik-lines",
+  "kelly-slab",
+  "exo-2",
+] as const satisfies readonly DisplayFontId[];
+
+export function displayFontNeedsHeroFluidMobile(id: DisplayFontId): boolean {
+  return (DISPLAY_FONT_HERO_FLUID_MOBILE_IDS as readonly string[]).includes(id);
+}
+
+/**
+ * Заголовки секций (h2): у пиксельных и узких гарнитур слишком широкий letter-spacing «разрывает» строку.
+ */
+export const DISPLAY_FONT_SECTION_TIGHT_TRACKING_IDS = [
+  "press-start-2p",
+  "rubik-mono-one",
+  "rubik-pixels",
+  "rubik-broken-fax",
+] as const satisfies readonly DisplayFontId[];
+
+export function displayFontNeedsSectionTightTracking(id: DisplayFontId): boolean {
+  return (DISPLAY_FONT_SECTION_TIGHT_TRACKING_IDS as readonly string[]).includes(id);
+}
+
+/** Press Start 2P: на мобилке ещё сильнее ужимаем трекинг — data-hero-title-pixel. */
+export function displayFontIsHeroPressStartPixel(id: DisplayFontId): boolean {
+  return id === "press-start-2p";
+}

--- a/src/fonts/cosmic-cyrillic-google.ts
+++ b/src/fonts/cosmic-cyrillic-google.ts
@@ -1,0 +1,238 @@
+import {
+  Dela_Gothic_One,
+  Exo_2,
+  Handjet,
+  Kablammo,
+  Kelly_Slab,
+  Orelega_One,
+  Pixelify_Sans,
+  Press_Start_2P,
+  Rubik_Broken_Fax,
+  Rubik_Glitch,
+  Rubik_Iso,
+  Rubik_Lines,
+  Rubik_Mono_One,
+  Rubik_Moonrocks,
+  Rubik_Pixels,
+  Rubik_Storm,
+  Rubik_Wet_Paint,
+  Ruslan_Display,
+  Russo_One,
+  Stalinist_One,
+  Tektur,
+  Train_One,
+  Unbounded,
+} from "next/font/google";
+
+/* Каждый вызов next/font — отдельная const; без spread (ограничение Turbopack + next/font). */
+const cosmicNasalization = Tektur({
+  display: "swap",
+  preload: false,
+  fallback: ["ui-sans-serif", "system-ui", "sans-serif"],
+  subsets: ["latin", "cyrillic", "cyrillic-ext"],
+  weight: "800",
+  variable: "--font-display-nasalization",
+});
+const cosmicZekton = Handjet({
+  display: "swap",
+  preload: false,
+  fallback: ["ui-sans-serif", "system-ui", "sans-serif"],
+  subsets: ["latin", "cyrillic", "cyrillic-ext"],
+  weight: "600",
+  variable: "--font-display-zekton",
+});
+const cosmicNeuropolX = Dela_Gothic_One({
+  display: "swap",
+  preload: false,
+  fallback: ["ui-sans-serif", "system-ui", "sans-serif"],
+  subsets: ["latin", "cyrillic", "latin-ext", "greek", "vietnamese"],
+  weight: "400",
+  variable: "--font-display-neuropol-x",
+});
+const cosmicSaiba45 = Kablammo({
+  display: "swap",
+  preload: false,
+  fallback: ["ui-sans-serif", "system-ui", "sans-serif"],
+  subsets: ["latin", "cyrillic", "cyrillic-ext", "emoji", "vietnamese"],
+  weight: "400",
+  variable: "--font-display-saiba-45",
+});
+const cosmicVivlRail = Pixelify_Sans({
+  display: "swap",
+  preload: false,
+  fallback: ["ui-sans-serif", "system-ui", "sans-serif"],
+  subsets: ["latin", "cyrillic", "latin-ext"],
+  weight: "600",
+  variable: "--font-display-vivl-rail",
+});
+const cosmicGoodFuture = Orelega_One({
+  display: "swap",
+  preload: false,
+  fallback: ["ui-sans-serif", "system-ui", "sans-serif"],
+  subsets: ["latin", "cyrillic", "cyrillic-ext", "latin-ext"],
+  weight: "400",
+  variable: "--font-display-good-future",
+});
+const cosmicTablon = Rubik_Storm({
+  display: "swap",
+  preload: false,
+  fallback: ["ui-sans-serif", "system-ui", "sans-serif"],
+  subsets: ["latin", "cyrillic", "cyrillic-ext", "hebrew"],
+  weight: "400",
+  variable: "--font-display-tablon",
+});
+const cosmicFreakShow = Rubik_Glitch({
+  display: "swap",
+  preload: false,
+  fallback: ["ui-sans-serif", "system-ui", "sans-serif"],
+  subsets: ["latin", "cyrillic", "cyrillic-ext", "hebrew"],
+  weight: "400",
+  variable: "--font-display-freak-show",
+});
+const cosmicPinnacle = Train_One({
+  display: "swap",
+  preload: false,
+  fallback: ["ui-sans-serif", "system-ui", "sans-serif"],
+  subsets: ["latin", "cyrillic", "latin-ext"],
+  weight: "400",
+  variable: "--font-display-pinnacle",
+});
+const cosmicTesla = Ruslan_Display({
+  display: "swap",
+  preload: false,
+  fallback: ["ui-sans-serif", "system-ui", "sans-serif"],
+  subsets: ["latin", "cyrillic", "latin-ext", "math", "symbols"],
+  weight: "400",
+  variable: "--font-display-tesla",
+});
+const cosmicUnbounded = Unbounded({
+  display: "swap",
+  preload: false,
+  fallback: ["ui-sans-serif", "system-ui", "sans-serif"],
+  subsets: ["latin", "cyrillic", "cyrillic-ext", "vietnamese"],
+  weight: "700",
+  variable: "--font-display-unbounded",
+});
+const cosmicRubikIso = Rubik_Iso({
+  display: "swap",
+  preload: false,
+  fallback: ["ui-sans-serif", "system-ui", "sans-serif"],
+  subsets: ["latin", "cyrillic", "cyrillic-ext", "hebrew", "latin-ext"],
+  weight: "400",
+  variable: "--font-display-rubik-iso",
+});
+const cosmicRubikLines = Rubik_Lines({
+  display: "swap",
+  preload: false,
+  fallback: ["ui-sans-serif", "system-ui", "sans-serif"],
+  subsets: ["latin", "cyrillic", "cyrillic-ext", "hebrew", "latin-ext", "math", "symbols"],
+  weight: "400",
+  variable: "--font-display-rubik-lines",
+});
+const cosmicRubikMoonrocks = Rubik_Moonrocks({
+  display: "swap",
+  preload: false,
+  fallback: ["ui-sans-serif", "system-ui", "sans-serif"],
+  subsets: ["latin", "cyrillic", "cyrillic-ext", "hebrew", "latin-ext"],
+  weight: "400",
+  variable: "--font-display-rubik-moonrocks",
+});
+const cosmicStalinistOne = Stalinist_One({
+  display: "swap",
+  preload: false,
+  fallback: ["ui-sans-serif", "system-ui", "sans-serif"],
+  subsets: ["latin", "cyrillic", "latin-ext"],
+  weight: "400",
+  variable: "--font-display-stalinist-one",
+});
+const cosmicKellySlab = Kelly_Slab({
+  display: "swap",
+  preload: false,
+  fallback: ["ui-sans-serif", "system-ui", "sans-serif"],
+  subsets: ["latin", "cyrillic", "latin-ext"],
+  weight: "400",
+  variable: "--font-display-kelly-slab",
+});
+const cosmicRussoOne = Russo_One({
+  display: "swap",
+  preload: false,
+  fallback: ["ui-sans-serif", "system-ui", "sans-serif"],
+  subsets: ["latin", "cyrillic", "latin-ext"],
+  weight: "400",
+  variable: "--font-display-russo-one",
+});
+const cosmicPressStart2P = Press_Start_2P({
+  display: "swap",
+  preload: false,
+  fallback: ["ui-monospace", "monospace"],
+  subsets: ["latin", "cyrillic", "cyrillic-ext", "greek", "latin-ext"],
+  weight: "400",
+  variable: "--font-display-press-start-2p",
+});
+const cosmicExo2 = Exo_2({
+  display: "swap",
+  preload: false,
+  fallback: ["ui-sans-serif", "system-ui", "sans-serif"],
+  subsets: ["latin", "cyrillic", "cyrillic-ext", "latin-ext", "vietnamese"],
+  weight: "700",
+  variable: "--font-display-exo-2",
+});
+const cosmicRubikPixels = Rubik_Pixels({
+  display: "swap",
+  preload: false,
+  fallback: ["ui-sans-serif", "system-ui", "sans-serif"],
+  subsets: ["latin", "cyrillic", "cyrillic-ext", "hebrew", "latin-ext"],
+  weight: "400",
+  variable: "--font-display-rubik-pixels",
+});
+const cosmicRubikBrokenFax = Rubik_Broken_Fax({
+  display: "swap",
+  preload: false,
+  fallback: ["ui-sans-serif", "system-ui", "sans-serif"],
+  subsets: ["latin", "cyrillic", "cyrillic-ext", "hebrew", "latin-ext", "math", "symbols"],
+  weight: "400",
+  variable: "--font-display-rubik-broken-fax",
+});
+const cosmicRubikWetPaint = Rubik_Wet_Paint({
+  display: "swap",
+  preload: false,
+  fallback: ["ui-sans-serif", "system-ui", "sans-serif"],
+  subsets: ["latin", "cyrillic", "cyrillic-ext", "hebrew", "latin-ext"],
+  weight: "400",
+  variable: "--font-display-rubik-wet-paint",
+});
+const cosmicRubikMonoOne = Rubik_Mono_One({
+  display: "swap",
+  preload: false,
+  fallback: ["ui-monospace", "monospace"],
+  subsets: ["latin", "cyrillic", "latin-ext"],
+  weight: "400",
+  variable: "--font-display-rubik-mono-one",
+});
+
+/** Экземпляры next/font — layout подключает variable, hero/section — className. */
+export const cosmicDisplayGoogle = {
+  nasalization: cosmicNasalization,
+  zekton: cosmicZekton,
+  "neuropol-x": cosmicNeuropolX,
+  "saiba-45": cosmicSaiba45,
+  "vivl-rail": cosmicVivlRail,
+  "good-future": cosmicGoodFuture,
+  tablon: cosmicTablon,
+  "freak-show": cosmicFreakShow,
+  pinnacle: cosmicPinnacle,
+  tesla: cosmicTesla,
+  unbounded: cosmicUnbounded,
+  "rubik-iso": cosmicRubikIso,
+  "rubik-lines": cosmicRubikLines,
+  "rubik-moonrocks": cosmicRubikMoonrocks,
+  "stalinist-one": cosmicStalinistOne,
+  "kelly-slab": cosmicKellySlab,
+  "russo-one": cosmicRussoOne,
+  "press-start-2p": cosmicPressStart2P,
+  "exo-2": cosmicExo2,
+  "rubik-pixels": cosmicRubikPixels,
+  "rubik-broken-fax": cosmicRubikBrokenFax,
+  "rubik-wet-paint": cosmicRubikWetPaint,
+  "rubik-mono-one": cosmicRubikMonoOne,
+};

--- a/src/fonts/display-font-classnames.ts
+++ b/src/fonts/display-font-classnames.ts
@@ -1,0 +1,10 @@
+import { DISPLAY_FONTS, type DisplayFontId } from "@/constants/display-font";
+import { cosmicDisplayGoogle } from "@/fonts/cosmic-cyrillic-google";
+
+/**
+ * className из next/font — тот же font-family, что и в @font-face.
+ * Собирается из DISPLAY_FONTS + cosmicDisplayGoogle, чтобы не дублировать ключи вручную.
+ */
+export const DISPLAY_FONT_CLASSNAMES = Object.fromEntries(
+  DISPLAY_FONTS.map((id) => [id, cosmicDisplayGoogle[id].className]),
+) as Record<DisplayFontId, string>;

--- a/src/ui/section/section.tsx
+++ b/src/ui/section/section.tsx
@@ -4,6 +4,9 @@ import type { ReactNode } from "react";
 
 import { motion } from "framer-motion";
 
+import { useDisplayFont } from "@/components/display-font/display-font-context";
+import { displayFontNeedsSectionTightTracking } from "@/constants/display-font";
+import { DISPLAY_FONT_CLASSNAMES } from "@/fonts/display-font-classnames";
 import { ScrambleRevealText } from "@/ui/scramble-reveal/scramble-reveal";
 
 type SectionProps = {
@@ -13,6 +16,11 @@ type SectionProps = {
 };
 
 export const Section = ({ id, children, title }: SectionProps) => {
+  const { id: displayFontId } = useDisplayFont();
+  const displayFontClass = DISPLAY_FONT_CLASSNAMES[displayFontId];
+  const sectionTitleTrackingClass = displayFontNeedsSectionTightTracking(displayFontId)
+    ? "tracking-tighter"
+    : "tracking-wide";
   const headingId = title ? `${id}-heading` : undefined;
 
   return (
@@ -28,7 +36,7 @@ export const Section = ({ id, children, title }: SectionProps) => {
       {title ? (
         <ScrambleRevealText
           as="h2"
-          className="bg-linear-to-r from-accent via-accent-light to-accent-secondary bg-clip-text py-4 text-3xl font-bold tracking-tighter text-transparent"
+          className={`${displayFontClass} bg-linear-to-r from-accent via-accent-light to-accent-secondary bg-clip-text py-4 text-3xl font-bold ${sectionTitleTrackingClass} text-transparent`}
           id={headingId}
           text={title}
         />


### PR DESCRIPTION
## Изменения

- Переключатель дисплейных шрифтов для hero, заголовков секций и логотипа; сохранение в `localStorage`.
- Подключение набора Google Fonts через `next/font`, переменные в root layout, автогенерация `DISPLAY_FONT_CLASSNAMES`.
- Доработка кибер-эффекта hero (псевдоэлементы, скан, data-атрибуты для трекинга/кегля).
- Мобильная карусель проектов: полноширинные слайды, стрелки навигации с `sm`.

Сборка и линт проверялись локально ранее.